### PR TITLE
add Delphix analytics collectors

### DIFF
--- a/analytics-collectors/bcchelper.py
+++ b/analytics-collectors/bcchelper.py
@@ -1,0 +1,480 @@
+#
+# Copyright (c) 2018, 2019 by Delphix. All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+from bcc import BPF
+from time import sleep
+from time import time
+import ctypes as ct
+import logging
+import re
+
+""" BCC Helper
+This module contains the BCCHelper class to aid in writing BCC Tracing
+scripts using a python front end and bpf C code.  See the bcc Reference
+Guide.
+https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#1-bpf
+
+Defitions for C helper routines and macros are in
+/opt/delphix/server/etc/bcc_helper.h
+
+BCC Helper focuses are printing out data from a set of tracing aggregations.
+There are three supported scalar types of aggregations(count, sum, and
+aversum(which requires a separate count aggregation)), two histogram
+aggregations(log histogram or linear log histogram), and a stand alone
+average aggegation.  It is assumed that for each aggregation in the helper
+there has been implemented in C code a BPF_HASH using a common hash key.
+The key is defined as a C struct with a required first member of timestamp(t)
+and a required last member of cpuid.  Other key members can be added for the
+key types needed for that collector.  For example the structure for the
+default nfs collector has an op value to keep separate reads and write
+statistics.
+
+typedef struct {
+    u64  t;
+    char op[OP_NAME_LEN];
+    u32  cpuid;
+} nfs_key_t;
+
+The C HIST_KEY macro defines histogram key that is derived from the
+base aggregation key and adds a slot elemtent.  For example, the
+nfs_hist_key_t is define with the following macro:
+
+HIST_KEY(nfs_hist_key_t, nfs_key_t);
+
+This is the structure that is defined:
+
+typedef struct {
+    nfs_key_t agg_key;
+    u64       slot;
+} nfs_hist_key_t;
+
+See appliance/server/core/src/main/resources/analytics/nfs_layer_linux.st
+for an example of how to structure C bcc code.  In the python code a
+BPF object and an equality function for the key structure are required
+to initialize a bcc Helper.  The equality function should return true
+for keys that match in all member fields except the cpuid.  Aggregation
+and key type objects are added to the helper that describe what is being
+traced.  With this initialization, the helper printall method can be called
+repeatedly.  Each call will clear all the aggregation items since
+the last one and output the data.  The values for each timestamp are
+kept separate.  Within each timestamp the values from different
+cpus(cpuid) are combined for matching keys for each aggregation.
+IF ANALYTICS_PRINT_MODE is specified json objects are generated with
+the value of each aggregation for each timestamp suitable to be used
+by the appliance analytics system such as:
+
+{"t":"1565031672", "op":"write", "count":"92", "throughput":"645120", \
+"avgLatency":"609497", "latency":" \
+{500000,17},{600000,38},{700000,21},{800000,6},{900000,9},{2000000,1},"}
+
+The default output mode produces human readable output showing for the
+purpose of debugging:
+
+count[1565031672, write] = 92
+
+throughput[1565031672, write] = 645120
+
+avgLatency[1565031672, write] = 609497
+
+latency[1565031672, write] =
+500000		17
+600000		38
+700000		21
+800000		6
+900000		9
+2000000		1
+"""
+
+
+class BCCHelper:
+    SUM_AGGREGATION = 0
+    COUNT_AGGREGATION = 1
+    AVERAGE_AGGREGATION = 2
+    AVERSUM_AGGREGATION = 3
+    # Logic in isHistogram() requires Histogram values > other aggregations
+    LOG_HISTOGRAM_AGGREGATION = 4
+    LL_HISTOGRAM_AGGREGATION = 5
+    DEFAULT_PRINT_MODE = 0
+    ANALYTICS_PRINT_MODE = 1
+    #
+    # For each key type, python string post-processing can be added in
+    # key_type_string(); much easier than in the bcc C code.
+    #
+    DEFAULT_KEY_TYPE = 0
+    IP_KEY_TYPE = 1
+
+    def __init__(self, b, equals, mode=DEFAULT_PRINT_MODE):
+        """ Initialize a bcchelper for a specific bpf instance given a
+        key equality functions.
+        """
+        self.b = b
+        self.equals = equals
+        self.mode = mode
+        self.epoch_time_delta = 0
+        self.aggregations = []
+        self.key_types = []
+        logging.basicConfig(level=logging.CRITICAL,
+                            format='%(asctime)s - %(levelname)s - %(message)s')
+        self.logger = logging.getLogger()
+
+    @staticmethod
+    def isHistogram(agg):
+        return (agg[1] >= BCCHelper.LOG_HISTOGRAM_AGGREGATION)
+
+    def next_key(self, agg_items):
+        """ Look at the head item of each aggregation's list and
+        return the aggregation key for the earliest entry
+        """
+        key = None
+        iagg = 0
+        for agglist in agg_items:
+            if len(agglist) > 0:
+                head = agglist[0]
+                if self.isHistogram(self.aggregations[iagg]):
+                    nkey = head[0].agg_key
+                else:
+                    nkey = head[0]
+                if key is None or nkey.t < key.t:
+                    key = nkey
+            iagg += 1
+        return key
+
+    def add_aggregation(self, name, type):
+        """ Add an aggregatation to print out. """
+
+        if type == self.AVERSUM_AGGREGATION:
+            #
+            # An aversum can only be added if there is a count aggregation
+            # that can be used to calculate the average
+            #
+            hascount = False
+            for v in self.aggregations:
+                hascount = hascount or (v[1] == self.COUNT_AGGREGATION)
+            if not hascount:
+                self.logger.error(
+                        "Error: Aversum aggregation requires a count")
+                return
+
+        self.aggregations.append([name, type, self.b.get_table(name)])
+
+    def add_key_type(self, name, type=None):
+        """This key type expected in all aggregation keys."""
+        if type is None:
+            type = self.DEFAULT_KEY_TYPE
+        self.key_types.append([name, type])
+
+    def walltime(self, ktime):
+        """Convert to an epoch timestamp."""
+        if self.epoch_time_delta == 0:
+            self.epoch_time_delta = int(time()) - ktime
+
+        return (ktime + self.epoch_time_delta)
+
+    @staticmethod
+    def log_lin_hist_value(slot):
+        """
+        The C code log_lin_hist_slot(<latency value>), returns a "slot value"
+        that indicates the histogram bucket for the given <latency value>.
+        Consider example range: 10000ns (10 microsecs) to 10000000000ns (10
+        seconds), that is: [10000, 100000, 1000000, 10000000, 100000000,
+        1000000000, 10000000000].  The "slot" values 0-8 => bucket 10000,
+        values 9-18 => bucket 100000, values 19-28 => bucket 1000000 and so on
+        upto slot=59-68 for bucket 10000000000
+
+        This method, given the "slot value", maps it back to
+        equivalent histogram buckets
+        Example:
+        Input "slot values" 4, 19 will return: 50000, 1000000
+        (indicating buckets 10000, 1000000 these belong to)
+        So, corresponding latency histogram would be:
+        "latency":"{{50000,2},{1000000,1}}"  (latency bucket, I/O count)
+        """
+        mag_values = [10000, 100000, 1000000, 10000000, 100000000,
+                      1000000000, 10000000000]
+        idx = slot / 10
+        if (idx >= len(mag_values)):
+            self.logger.debug("log_lin_hist_value slot: %d out of range", slot)
+            return -1
+        else:
+            value = mag_values[idx]
+            value += value * (slot % 10)
+
+        return value
+
+    def histogram_entry(self, hist_type, slot, value):
+        """ Generate the text for one entry in a histogram"""
+        if (self.mode == self.ANALYTICS_PRINT_MODE):
+            if hist_type == BCCHelper.LOG_HISTOGRAM_AGGREGATION:
+                return "{" + str(pow(2, slot) - 1) + "," + \
+                      str(value) + "}"
+            else:
+                return "{" + str(BCCHelper.log_lin_hist_value(slot)) + \
+                         "," + str(value) + "}"
+        else:
+            if hist_type == BCCHelper.LOG_HISTOGRAM_AGGREGATION:
+                return "\n" + str(pow(2, slot) - 1) + "\t" + str(value)
+            else:
+                return "\n" + str(BCCHelper.log_lin_hist_value(slot)) + \
+                       "\t" + str(value) 
+
+    def output_histogram(self, hist_items, hist_type):
+        """ Output a histogram
+        The hist_items all have the same key values but different cpu
+        ids and slots.  Sort the items by slot and then sum up the hit
+        count values for all the items for each slot as the list is
+        traversed.  When a new slot is encountered, add an entry to the
+        output for the old slot.
+        """
+        if (len(hist_items) == 0):
+            if (self.mode == self.ANALYTICS_PRINT_MODE):
+                return "{ }"
+            return ""
+
+        h = ""
+        hist_items.sort(key=lambda x: x[0].slot)
+        slot = -1
+        value = 0
+        for k, v in hist_items:
+            if slot != k.slot and slot != -1:
+                h += self.histogram_entry(hist_type, slot, value)
+                if (self.mode == self.ANALYTICS_PRINT_MODE):
+                    h += ","
+                value = 0
+            slot = k.slot
+            value += v.value
+        h += self.histogram_entry(hist_type, slot, value)
+        return h
+
+    def aggregation_lookup(self, items, key):
+        """ Search key-value list for items that match a key"""
+        agg_items = []
+        for item in items:
+            if (self.equals(item[0], key)):
+                agg_items.append(item)
+
+        return agg_items
+
+    def histogram_lookup(self, items, key):
+        """ Search histogram list for items that match the aggregation key.
+        The top level key has two parts: agg_key and slot.  All items that
+        match the agg_key go into one histogram.
+        """
+        hist_items = []
+        for item in items:
+            if (self.equals(item[0].agg_key, key)):
+                hist_items.append(item)
+
+        return hist_items
+
+    def key_type_string(self, key, key_type):
+        """
+        Generate the output string for a member of a key.  The value collected
+        is post-processed based on the key type:
+          DEFAULT_KEY_TYPE - no post-processing needed
+          IP_KEY_TYPE - strips unwanted symbols from IPV4 literal address
+        """
+        keystr = str(getattr(key, key_type[0]))
+
+        # Extract IPv4 literal address, often preceded by "*," or ","
+        if key_type[1] == self.IP_KEY_TYPE:
+            match = re.search("\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", keystr)
+            #
+            # Update key if IP match was found, if there is no match return
+            # the raw key back unchanged
+            #
+            if match:
+                keystr = str(match.group())
+
+        return keystr
+
+    def combined_average(self, agg_items):
+        """ combine values from a list of average aggregations items"""
+        sum = 0
+        count = 0
+        for item in agg_items:
+            sum += item[1].sum
+            count += item[1].count
+
+        if count:
+            return sum / count
+        else:
+            return 0
+
+    def combined_scalar_value(self, agg_items):
+        """ combine values from a list of scalar aggregations items"""
+        value = 0
+        if len(agg_items) == 0:
+            return value
+
+        for item in agg_items:
+            value += item[1].value
+        return value
+
+    def get_ordered_items(self):
+        """ clear all data items from aggregations in the helper and sort them
+        so that items with the same key signatures are together.  The items are
+        key-value pairs.  For the scalar aggregations the key will be made of
+        of key types corresponding to the key structure used in bcc collection
+        code(see module comment).  The aggregation type determines the type of
+        value.  For example, the items for the count aggregation might look
+        like this for the default nfs collector.  The key is a tuple with a
+        timestamp, an operation string and a cpuid.
+        { (1565031673, "read", 342) : 1}
+        { (1565031672, "write", 342) : 40}
+        { (1565031672, "read", 342) : 2}
+        { (1565031672, "write", 76) : 52}
+        The items are sorted so by the key signature (all items except the
+        cpu id) that items with the same signature can be easily combined.
+        { (1565031672, "read", 342) : 2}
+        { (1565031672, "write", 342) : 40}
+        { (1565031672, "write", 76) : 52}
+        { (1565031673, "read", 342) : 1}
+        """
+        agg_items = []
+
+        # Copy the data out of the aggregation tables and clear them
+        for agg in self.aggregations:
+            table = agg[2]
+            items = table.items()
+            table.clear()
+            #
+            # Sort aggregation items so datapoints with the same key signatures
+            # but different cpu ids with be grouped together
+            #
+            if self.isHistogram(agg):
+                for key in self.key_types:
+                    items.sort(key=lambda x: getattr(x[0].agg_key, key[0]))
+                items.sort(key=lambda x: x[0].agg_key.t)
+            else:
+                for key in self.key_types:
+                    items.sort(key=lambda x: getattr(x[0], key[0]))
+                items.sort(key=lambda x: x[0].t)
+            agg_items.append(items)
+
+        return agg_items
+
+    def get_key_output_string(self, key):
+        """ Generate a string to output a key in the specified mode.
+        For analytics mode generate json with key value pairs for
+        the time stamp and each element, such as:
+            {"t":"1565031672", "op":"write"
+        For default mode output the values as an associative array index:
+            [1565031672, write]"""
+        if (self.mode == self.ANALYTICS_PRINT_MODE):
+            keystr = "{\"t\":\"" + str(self.walltime(key.t)) + "\""
+            for key_type in self.key_types:
+                keystr += ", \"" + key_type[0] + "\":\"" + \
+                        self.key_type_string(key, key_type) + "\""
+        else:
+            keystr = "[" + str(self.walltime(key.t))
+            for key_type in self.key_types:
+                keystr += ", "
+                keystr += self.key_type_string(key, key_type)
+            keystr += "]"
+        return keystr
+
+    def get_matching_items(self, agg, agg_items, key):
+        """ Get a list of items that match a key. There are multiple
+        items as there can be one for each running cpu.
+        """
+        if self.isHistogram(agg):
+            items = self.histogram_lookup(agg_items, key)
+        else:
+            items = self.aggregation_lookup(agg_items, key)
+        return items
+
+    def combine_items(self, agg, items, count_val):
+        """ Combine items with the same key to produce one value.  The
+        aggregation type determines what is needed to combine values.
+        """
+        if self.isHistogram(agg):
+            com_val = self.output_histogram(items, agg[1])
+        else:
+            if len(items) is 0:
+                com_val = 0
+            elif (agg[1] == self.AVERAGE_AGGREGATION):
+                com_val = self.combined_average(items)
+            else:
+                com_val = self.combined_scalar_value(items)
+                if (agg[1] == self.AVERSUM_AGGREGATION):
+                    if count_val:
+                        com_val = com_val / count_val
+                    else:
+                        com_val = 0
+        return com_val
+
+    def remove_items(self, agg_items, items):
+        """ Remove items already processed from the agg_items list.
+        """
+        for item in items:
+            agg_items.remove(item)
+
+    def items_to_string(self, agg_items):
+        """ The output string for the agg_items contains records for each
+        key signature in agg_items.  Each record will include the values of
+        the key types and a value from each aggregation.  Not all aggregations
+        are guaranteed to have a item for each key signature due to race
+        conditions around the edge of collection interval boundaries.  Some
+        aggregations with have multiple items with the same signature from
+        different cpus.  These items will be combined into one value.  The
+        records are ordered by timestamps.
+        """
+        outstr = ""
+        #
+        # During the body of the loop a record for each base_key will be added
+        # to outstr.  The record contains a value for each aggregation that is
+        # produces by combining the values from all that aggregation's items
+        # that match base_key.  Note that a value doesn't mean a scalar value,
+        # e.g. a value for a histogram aggregation is a single histogram.
+        # Those matching items will also be removed from agg_items so that the
+        # calls to next_key() will iterate through all keys leaving agg_items
+        # empty.
+        #
+        base_key = self.next_key(agg_items)
+        while base_key is not None:
+
+            keystr = self.get_key_output_string(base_key)
+            # analytic records include the keystr at the begginning of json
+            if (self.mode == self.ANALYTICS_PRINT_MODE):
+                outstr += keystr
+
+            # add the value from each aggregation to this record
+            count_val = 0
+            iagg = 0
+            for agg in self.aggregations:
+                items = self.get_matching_items(agg, agg_items[iagg], base_key)
+                val = self.combine_items(agg, items, count_val)
+                self.remove_items(agg_items[iagg], items)
+                #
+                # save the value from COUNT aggregations to be used by any
+                # following AVERSUM aggregations, see add_aggregation()
+                #
+                if (agg[1] == self.COUNT_AGGREGATION):
+                    count_val = val
+                iagg = iagg + 1
+
+                if (self.mode == self.ANALYTICS_PRINT_MODE):
+                    outstr += ", \"" + agg[0] + "\":\""
+                    outstr += str(val)
+                    outstr += "\""
+                else:
+                    outstr += agg[0] + keystr + " = "
+                    outstr += str(val)
+                    outstr += "\n\n"
+
+            # close the json for analytic records
+            if (self.mode == self.ANALYTICS_PRINT_MODE):
+                outstr += "}\n\n"
+
+            base_key = self.next_key(agg_items)
+        return outstr
+
+    def printall(self):
+        """ Print and clear all data from aggregations in the helper."""
+        agg_items = self.get_ordered_items()
+        outstr = self.items_to_string(agg_items)
+        # The trailing comma prevents the print from adding a newline.
+        print outstr,

--- a/analytics-collectors/io.st
+++ b/analytics-collectors/io.st
@@ -1,0 +1,149 @@
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+from bcc import BPF
+from time import sleep
+from time import time
+import datetime
+import ctypes as ct
+import sys
+from bcchelper import BCCHelper
+
+# BPF disk io program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/bpf_common.h>
+#include <linux/blkdev.h>
+#include <linux/blk_types.h>
+#include <uapi/linux/bpf.h>
+#include "/opt/delphix/server/etc/bcc_helper.h"
+
+
+// Definitions for this script
+#define READ_STR "read"
+#define WRITE_STR "write"
+#define OP_NAME_LEN 6
+
+// Structure to hold thread local data
+typedef struct {
+    u64 ts;
+    unsigned int size;
+    unsigned int cmd_flags;
+    u32 err;
+    char device[DISK_NAME_LEN];
+} io_data_t;
+
+// Key structure for scalar aggegations maps
+typedef struct {
+    u64  t;
+    $keys:{key| $key.declaration$
+    }$
+    u64  cpuid;
+} io_key_t;
+
+HIST_KEY(io_hist_key_t, io_key_t);
+
+BPF_HASH(io_base_data, u64, io_data_t);
+$maps:{map|
+BPF_HASH($map.name$, io_key_t, $map.type$);
+}$
+$hists:{hist|
+BPF_HASH($hist.name$, io_hist_key_t, u64);
+}$
+
+int disk_io_start(struct pt_regs *ctx, struct request *reqp)
+{
+    io_data_t data = {};
+    struct gendisk *diskp = reqp->rq_disk;
+    data.ts = bpf_ktime_get_ns();
+    data.cmd_flags = reqp->cmd_flags;
+    data.size = reqp->__data_len;
+    __builtin_memcpy(&data.device, diskp->disk_name, DISK_NAME_LEN);
+    io_base_data.update((u64 *) &reqp, &data);
+    return 0;
+}
+
+static int aggregate_data(io_data_t *data, u64 ts, char *opstr)
+{
+    u64 delta;
+    io_key_t key = {};
+
+    delta = ts - data->ts;
+    key.t = ts / $collection_period_in_ns$;
+    key.cpuid = bpf_get_smp_processor_id();
+    $keys:{key| $key.collect$
+    }$
+
+    $maps:{map|
+        $map.aggregation$;
+    }$
+
+    io_hist_key_t hist_key = {};
+    hist_key.agg_key = key;
+
+    $hists:{hist|
+        hist_key.slot = $hist.slot$;
+        $hist.name$.increment(hist_key);
+    }$
+
+    return 0;
+}
+
+int disk_io_done(struct pt_regs *ctx, struct request *reqp)
+{
+    u64 ts = bpf_ktime_get_ns();
+    io_data_t *data = io_base_data.lookup((u64 *) &reqp);
+    struct bio *bp = reqp->bio;
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    data->err = (bp->bi_status == BLK_STS_OK) ? 0 : 1;
+
+    // Perform aggregations
+    if ((data->cmd_flags & REQ_OP_MASK) == REQ_OP_WRITE) {
+        aggregate_data(data, ts, WRITE_STR);
+    } else {
+        aggregate_data(data, ts, READ_STR);
+    }
+
+    io_base_data.delete((u64 *) &reqp);
+    return 0;
+}
+"""
+
+
+def io_key_equals(key1, key2):
+    return key1.t == key2.t \\
+           $keys:{key| and key1.$key.name$ == key2.$key.name$ \\
+           }$
+
+b = BPF(text=bpf_text)
+
+b.attach_kprobe(event="blk_start_request", fn_name="disk_io_start")
+b.attach_kprobe(event="blk_mq_start_request", fn_name="disk_io_start")
+b.attach_kprobe(event="blk_account_io_completion", fn_name="disk_io_done")
+
+
+helper = BCCHelper(b, io_key_equals, BCCHelper.ANALYTICS_PRINT_MODE)
+$maps:{map|
+helper.add_aggregation("$map.name$", BCCHelper.$map.aggtype$)
+}$
+$hists:{hist|
+helper.add_aggregation("$hist.name$", BCCHelper.$hist.aggtype$)
+}$
+$keys:{key|
+helper.add_key_type("$key.name$", BCCHelper.$key.keytype$)
+}$
+
+while (1):
+    try:
+        sleep(1)
+    except KeyboardInterrupt:
+        exit()
+
+    helper.printall()

--- a/analytics-collectors/iscsi.st
+++ b/analytics-collectors/iscsi.st
@@ -1,0 +1,146 @@
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+from bcc import BPF
+from time import sleep
+from time import time
+import datetime
+import ctypes as ct
+import sys
+sys.path.append('/opt/delphix/server/bin')
+from bcchelper import BCCHelper
+
+# BPF txg program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/bpf_common.h>
+#include <uapi/linux/bpf.h>
+#include "/opt/delphix/server/etc/bcc_helper.h"
+
+#include "target/iscsi/iscsi_target_core.h"
+
+
+// Definitions for this script
+#define READ_STR "read"
+#define WRITE_STR "write"
+
+// Structure to hold thread local data
+#define OP_NAME_LEN 6
+typedef struct {
+    u64 ts;
+    u64 flags;
+    u64 size;
+} iscsi_data_t;
+
+// Key structure for scalar aggegations maps
+typedef struct {
+    u64  t;
+    $keys:{key| $key.declaration$
+    }$
+    u32  cpuid;
+} iscsi_key_t;
+
+HIST_KEY(iscsi_hist_key_t, iscsi_key_t);
+
+BPF_HASH(iscsi_base_data, u64, iscsi_data_t);
+$maps:{map|
+BPF_HASH($map.name$, iscsi_key_t, $map.type$);
+}$
+$hists:{hist|
+BPF_HASH($hist.name$, iscsi_hist_key_t, u64);
+}$
+
+// Probe functions to initialize thread local data
+int iscsi_target_start(struct pt_regs *ctx, struct iscsi_conn *conn, struct iscsi_cmd *cmd, struct iscsi_scsi_req *hdr)
+{
+    iscsi_data_t data = {};
+    data.ts = bpf_ktime_get_ns();
+    data.flags = hdr->flags;
+    data.size = hdr->data_length;
+    iscsi_base_data.update((u64 *) &cmd, &data);
+
+    return 0;
+}
+
+static int aggregate_data(iscsi_data_t *data, u64 ts, char *opstr)
+{
+    u64 delta;
+    iscsi_key_t key = {};
+
+    delta = ts - data->ts;
+    key.t = ts / $collection_period_in_ns$;
+    key.cpuid = bpf_get_smp_processor_id();
+    $keys:{key| $key.collect$
+    }$
+
+    $maps:{map|
+        $map.aggregation$;
+    }$
+
+    iscsi_hist_key_t hist_key = {};
+    hist_key.agg_key = key;
+
+    $hists:{hist|
+        hist_key.slot = $hist.slot$;
+        $hist.name$.increment(hist_key);
+    }$
+
+    return 0;
+}
+
+int iscsi_target_end(struct pt_regs *ctx, struct iscsi_cmd *cmd)
+{
+    u64 ts = bpf_ktime_get_ns();
+    iscsi_data_t *data = iscsi_base_data.lookup((u64 *) &cmd);
+    u64 delta;
+    iscsi_key_t key = {};
+    char *opstr;
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    if (data->flags & ISCSI_FLAG_CMD_READ) {
+        aggregate_data(data, ts, READ_STR);
+    } else if (data->flags & ISCSI_FLAG_CMD_WRITE) {
+        aggregate_data(data, ts, WRITE_STR);
+    }
+    iscsi_base_data.delete((u64 *) &cmd);
+
+    return 0;
+}
+
+"""
+
+def iscsi_key_equals(key1, key2):
+    return key1.t == key2.t \\
+           $keys:{key| and key1.$key.name$ == key2.$key.name$ \\
+           }$
+
+
+b = BPF(text=bpf_text)
+
+b.attach_kprobe(event="iscsit_process_scsi_cmd", fn_name="iscsi_target_start")
+b.attach_kprobe(event="iscsit_build_rsp_pdu", fn_name="iscsi_target_end")
+
+helper = BCCHelper(b, iscsi_key_equals, BCCHelper.ANALYTICS_PRINT_MODE)
+$maps:{map|
+helper.add_aggregation("$map.name$", BCCHelper.$map.aggtype$)
+}$
+$hists:{hist|
+helper.add_aggregation("$hist.name$", BCCHelper.$hist.aggtype$)
+}$
+$keys:{key|
+helper.add_key_type("$key.name$", BCCHelper.$key.keytype$)
+}$
+
+while (1):
+    try:
+        sleep(1)
+    except KeyboardInterrupt:
+        exit()
+
+    helper.printall()

--- a/analytics-collectors/nfs.st
+++ b/analytics-collectors/nfs.st
@@ -1,0 +1,337 @@
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+from bcc import BPF
+from time import sleep
+from time import time
+import datetime
+import ctypes as ct
+import sys
+from bcchelper import BCCHelper
+
+# BPF txg program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/bpf_common.h>
+#include <uapi/linux/bpf.h>
+#include <linux/sunrpc/svc.h>
+#include "/opt/delphix/server/etc/bcc_helper.h"
+
+
+// nfsd4 definitions from fs/nfsd/xdr4.h
+#define u32 unsigned int
+#define u64 unsigned long long
+#define bool int
+
+typedef struct {
+        u32             cl_boot;
+        u32             cl_id;
+} clientid_t;
+
+typedef struct {
+        clientid_t      so_clid;
+        u32             so_id;
+} stateid_opaque_t;
+
+typedef struct {
+        u32                     si_generation;
+        stateid_opaque_t        si_opaque;
+} stateid_t;
+
+typedef struct {
+        stateid_t       rd_stateid;     /* request */
+        u64		rd_offset;      /* request */
+        u32             rd_length;      /* request */
+        int             rd_vlen;
+        struct file     *rd_filp;
+        bool            rd_tmp_file;
+
+        void            *rd_rqstp;      /* response */
+        void            *rd_fhp;        /* response */
+} nfsd4_read;
+
+#define NFS4_VERIFIER_SIZE      8
+typedef struct { char data[NFS4_VERIFIER_SIZE]; } nfs4_verifier;
+
+typedef struct {
+        stateid_t       wr_stateid;         /* request */
+        u64             wr_offset;          /* request */
+        u32             wr_stable_how;      /* request */
+        u32             wr_buflen;          /* request */
+        struct kvec     wr_head;
+        struct page **  wr_pagelist;        /* request */
+        u32             wr_bytes_written;   /* response */
+        u32             wr_how_written;     /* response */
+        nfs4_verifier   wr_verifier;        /* response */
+} nfsd4_write;
+
+// Definitions for this script
+#define READ_STR "read"
+#define WRITE_STR "write"
+#define NFSV3_STR "v3"
+#define NFSV4_STR "v4"
+#define OP_NAME_LEN 6
+#define VER_NAME_LEN 3
+// Max length for null terminated string with ipv4 literal address
+#define MAX_IP_STRING 16
+// Client ip is sometimes proceeded by "*," or ","
+#define CLIENT_PREFIX_LEN 2
+#define CLIENT_LEN (MAX_IP_STRING + CLIENT_PREFIX_LEN)
+#define SYNC_WRITE  1
+#define ASYNC_WRITE 0
+#define CACHED_READ 1
+#define NONCACHED_READ 0
+#define AXIS_NOT_APPLICABLE -1
+
+// Structure to hold thread local data
+typedef struct {
+    u64 ts;
+    u64 size;
+    void *write_arg;
+    int sync;   // 1=sync write, 0=async write, -1=read
+    int cached; // 1=cached read, 0=non-cached read, -1=write
+    char client[CLIENT_LEN];
+} nfs_data_t;
+
+// Key structure for scalar aggegations maps
+typedef struct {
+    u64  t;
+    $keys:{key| $key.declaration$
+    }$
+    u32  cpuid;
+} nfs_key_t;
+
+HIST_KEY(nfs_hist_key_t, nfs_key_t);
+
+BPF_HASH(nfs_base_data, u32, nfs_data_t);
+$maps:{map|
+BPF_HASH($map.name$, nfs_key_t, $map.type$);
+}$
+$hists:{hist|
+BPF_HASH($hist.name$, nfs_hist_key_t, u64);
+}$
+
+// Probe functions to initialize thread local data
+int nfsd3_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
+    u64 offset, void *vec, int vlen, u32 *count)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    nfs_data_t data = {};
+    data.ts = bpf_ktime_get_ns();
+    data.write_arg = count;
+    data.sync = AXIS_NOT_APPLICABLE;
+    data.cached = CACHED_READ; // Assume cache hit, misses detected
+    bpf_probe_read_str(&data.client, CLIENT_LEN, rqstp->rq_client->name);
+    nfs_base_data.update(&pid, &data);
+    return 0;
+}
+
+int nfsd3_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
+    u64 offset, void *vec, int vlen, u32 *count)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    nfs_data_t data = {};
+    data.ts = bpf_ktime_get_ns();
+    data.write_arg = count;
+    data.sync = ASYNC_WRITE; // Assume async write, sync writes detected
+    data.cached = AXIS_NOT_APPLICABLE;
+    bpf_probe_read_str(&data.client, CLIENT_LEN, rqstp->rq_client->name);
+    nfs_base_data.update(&pid, &data);
+    return 0;
+}
+
+int nfsd4_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *cstate,
+    nfsd4_read *nfs_read)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    nfs_data_t data = {};
+    data.ts = bpf_ktime_get_ns();
+    data.size = nfs_read->rd_length;
+    data.write_arg = 0;
+    data.sync = AXIS_NOT_APPLICABLE;
+    data.cached = CACHED_READ; // Assume cache hit, misses detected
+    bpf_probe_read_str(&data.client, CLIENT_LEN, rqstp->rq_client->name);
+    nfs_base_data.update(&pid, &data);
+    return 0;
+}
+
+int nfsd4_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *cstate,
+    nfsd4_write *nfs_write)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    nfs_data_t data = {};
+    data.ts = bpf_ktime_get_ns();
+    data.size = 0;
+    data.write_arg = nfs_write;
+    data.sync = ASYNC_WRITE; // Assume async write, sync writes detected
+    data.cached = AXIS_NOT_APPLICABLE;
+    bpf_probe_read_str(&data.client, CLIENT_LEN, rqstp->rq_client->name);
+    nfs_base_data.update(&pid, &data);
+
+    return 0;
+}
+
+int nfs_cache_miss(struct pt_regs *ctx)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    nfs_data_t *data = nfs_base_data.lookup(&pid);
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    data->cached = NONCACHED_READ;
+
+    return 0;
+}
+
+int zil_commit_start(struct pt_regs *ctx)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    nfs_data_t *data = nfs_base_data.lookup(&pid);
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    data->sync = SYNC_WRITE;
+    return 0;
+}
+
+
+// Perform aggregations
+static int aggregate_data(nfs_data_t *data, u64 ts, char *opstr, char *verstr)
+{
+    u64 delta;
+    delta = ts - data->ts;
+
+    nfs_key_t key = {};
+    $keys:{key| $key.collect$
+    }$
+    key.t = ts / $collection_period_in_ns$;
+    key.cpuid = bpf_get_smp_processor_id();
+
+    $maps:{map|
+        $map.aggregation$;
+    }$
+
+    nfs_hist_key_t hist_key = {};
+    hist_key.agg_key = key;
+
+    $hists:{hist|
+        hist_key.slot = $hist.slot$;
+        $hist.name$.increment(hist_key);
+    }$
+
+    return 0;
+}
+
+static int nfsd3_aggregate_data(u64 ts, char *opstr)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    nfs_data_t *data = nfs_base_data.lookup(&pid);
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+    bpf_probe_read(&data->size, sizeof(u32), data->write_arg);
+
+    aggregate_data(data, ts, opstr, NFSV3_STR);
+    nfs_base_data.delete(&pid);
+
+    return 0;
+}
+
+// Probe functions to aggregate data
+int nfsd3_read_done(struct pt_regs *ctx)
+{
+    u64 ts = bpf_ktime_get_ns();
+    return nfsd3_aggregate_data(ts, READ_STR);
+}
+
+int nfsd3_write_done(struct pt_regs *ctx)
+{
+    u64 ts = bpf_ktime_get_ns();
+    return nfsd3_aggregate_data(ts, WRITE_STR);
+}
+
+int nfsd4_read_done(struct pt_regs *ctx)
+{
+    u64 ts = bpf_ktime_get_ns();
+    u32 pid = bpf_get_current_pid_tgid();
+    nfs_data_t *data = nfs_base_data.lookup(&pid);
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    aggregate_data(data, ts, READ_STR, NFSV4_STR);
+    nfs_base_data.delete(&pid);
+
+    return 0;
+}
+
+int nfsd4_write_done(struct pt_regs *ctx)
+{
+    u64 ts = bpf_ktime_get_ns();
+    u32 pid = bpf_get_current_pid_tgid();
+    nfs_data_t *data = nfs_base_data.lookup(&pid);
+    nfsd4_write nfs_write;
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    bpf_probe_read(&nfs_write, sizeof(nfs_write), data->write_arg);
+    data->size = nfs_write.wr_bytes_written;
+
+    aggregate_data(data, ts, WRITE_STR, NFSV4_STR);
+    nfs_base_data.delete(&pid);
+
+    return 0;
+}
+"""
+
+
+def nfs_key_equals(key1, key2):
+    return key1.t == key2.t \\
+           $keys:{key| and key1.$key.name$ == key2.$key.name$ \\
+           }$
+
+
+b = BPF(text=bpf_text)
+
+b.attach_kprobe(event="nfsd_read", fn_name="nfsd3_read_start")
+b.attach_kprobe(event="nfsd_write", fn_name="nfsd3_write_start")
+b.attach_kretprobe(event="nfsd_read", fn_name="nfsd3_read_done")
+b.attach_kretprobe(event="nfsd_write", fn_name="nfsd3_write_done")
+b.attach_kprobe(event="nfsd4_read", fn_name="nfsd4_read_start")
+b.attach_kprobe(event="nfsd4_write", fn_name="nfsd4_write_start")
+b.attach_kretprobe(event="nfsd4_read_release", fn_name="nfsd4_read_done")
+b.attach_kretprobe(event="nfsd4_write", fn_name="nfsd4_write_done")
+b.attach_kprobe(event="trace_zfs_arc__miss", fn_name="nfs_cache_miss")
+b.attach_kprobe(event="trace_zfs_blocked__read", fn_name="nfs_cache_miss")
+b.attach_kprobe(event="zil_commit", fn_name="zil_commit_start")
+
+
+helper = BCCHelper(b, nfs_key_equals, BCCHelper.ANALYTICS_PRINT_MODE)
+$maps:{map|
+helper.add_aggregation("$map.name$", BCCHelper.$map.aggtype$)
+}$
+$hists:{hist|
+helper.add_aggregation("$hist.name$", BCCHelper.$hist.aggtype$)
+}$
+$keys:{key|
+helper.add_key_type("$key.name$", BCCHelper.$key.keytype$)
+}$
+
+while (1):
+    try:
+        sleep(1)
+    except KeyboardInterrupt:
+        exit()
+
+    helper.printall()

--- a/analytics-collectors/vfs.st
+++ b/analytics-collectors/vfs.st
@@ -1,0 +1,218 @@
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+from bcc import BPF
+from time import sleep
+from time import time
+import datetime
+import ctypes as ct
+import sys
+from bcchelper import BCCHelper
+
+# BPF txg program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/bpf_common.h>
+#include <uapi/linux/bpf.h>
+#include "/opt/delphix/server/etc/bcc_helper.h"
+
+// Definitions for this script
+#define READ_STR "read"
+#define WRITE_STR "write"
+#define SYNC_WRITE  1
+#define ASYNC_WRITE 0
+#define CACHED_READ 1
+#define NONCACHED_READ 0
+#define AXIS_NOT_APPLICABLE -1
+
+// Structure to hold thread local data
+#define OP_NAME_LEN 6
+typedef struct {
+    u64 ts;
+    u64 size;
+    int sync;
+    int cached;
+    int zfs;
+} vfs_data_t;
+
+// Key structure for scalar aggegations maps
+typedef struct {
+    u64  t;
+    $keys:{key| $key.declaration$
+    }$
+    u32  cpuid;
+} vfs_key_t;
+
+HIST_KEY(vfs_hist_key_t, vfs_key_t);
+
+BPF_HASH(vfs_base_data, u32, vfs_data_t);
+$maps:{map|
+BPF_HASH($map.name$, vfs_key_t, $map.type$);
+}$
+$hists:{hist|
+BPF_HASH($hist.name$, vfs_hist_key_t, u64);
+}$
+
+// Probe functions to initialize thread local data
+int vfs_start(struct pt_regs *ctx, void *file, void *user_buf,
+			       u64 count, void *ppos)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    vfs_data_t data = {};
+    data.ts = bpf_ktime_get_ns();
+    data.size = count;
+    data.sync = AXIS_NOT_APPLICABLE; // Only applies to writes
+    data.cached = AXIS_NOT_APPLICABLE; // Only applies to reads
+    data.zfs = 0; // Assume it's not zfs, zfs calls detected
+    vfs_base_data.update(&pid, &data);
+    return 0;
+}
+
+int zfs_read_start(struct pt_regs *ctx)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    vfs_data_t *data = vfs_base_data.lookup(&pid);
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    data->cached = CACHED_READ; // Assume cache hit, misses detected
+    data->zfs = 1;              // This is a zfs operation
+    return 0;
+}
+
+int zfs_write_start(struct pt_regs *ctx)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    vfs_data_t *data = vfs_base_data.lookup(&pid);
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    data->zfs = 1;            // This is a zfs operation
+    data->sync = ASYNC_WRITE; // Assume async write, sync writes detected
+    return 0;
+}
+
+int vfs_cache_miss(struct pt_regs *ctx)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    vfs_data_t *data = vfs_base_data.lookup(&pid);
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+    data->cached = NONCACHED_READ;
+
+    return 0;
+}
+
+int zil_commit_start(struct pt_regs *ctx)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    vfs_data_t *data = vfs_base_data.lookup(&pid);
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+    data->sync =  SYNC_WRITE;
+
+    return 0;
+}
+
+// Perform aggregations
+static int vfs_aggregate_data(u64 ts, char *opstr)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    vfs_data_t *data = vfs_base_data.lookup(&pid);
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    if (data->zfs == 0) {
+        vfs_base_data.delete(&pid);
+        return 0;   // not a zfs op
+    }
+
+    u64 delta;
+    delta = ts - data->ts;
+
+    vfs_key_t key = {};
+    $keys:{key| $key.collect$
+    }$
+    key.t = ts / $collection_period_in_ns$;
+    key.cpuid = bpf_get_smp_processor_id();
+
+    $maps:{map|
+        $map.aggregation$;
+    }$
+
+    vfs_hist_key_t hist_key = {};
+    hist_key.agg_key = key;
+
+    $hists:{hist|
+        hist_key.slot = $hist.slot$;
+        $hist.name$.increment(hist_key);
+    }$
+
+    vfs_base_data.delete(&pid);
+    return 0;
+}
+
+// Probe functions to aggregate data
+int vfs_read_done(struct pt_regs *ctx)
+{
+    u64 ts = bpf_ktime_get_ns();
+    return vfs_aggregate_data(ts, READ_STR);
+}
+
+int vfs_write_done(struct pt_regs *ctx)
+{
+    u64 ts = bpf_ktime_get_ns();
+    return vfs_aggregate_data(ts, WRITE_STR);
+}
+"""
+
+
+def vfs_key_equals(key1, key2):
+    return key1.t == key2.t \\
+           $keys:{key| and key1.$key.name$ == key2.$key.name$ \\
+           }$
+
+
+b = BPF(text=bpf_text)
+
+b.attach_kprobe(event="vfs_read", fn_name="vfs_start")
+b.attach_kprobe(event="vfs_write", fn_name="vfs_start")
+b.attach_kretprobe(event="vfs_read", fn_name="vfs_read_done")
+b.attach_kretprobe(event="vfs_write", fn_name="vfs_write_done")
+b.attach_kprobe(event="zfs_read", fn_name="zfs_read_start")
+b.attach_kprobe(event="zfs_write", fn_name="zfs_write_start")
+b.attach_kprobe(event="trace_zfs_arc__miss", fn_name="vfs_cache_miss")
+b.attach_kprobe(event="trace_zfs_blocked__read", fn_name="vfs_cache_miss")
+b.attach_kprobe(event="zil_commit", fn_name="zil_commit_start")
+
+helper = BCCHelper(b, vfs_key_equals, BCCHelper.ANALYTICS_PRINT_MODE)
+$maps:{map|
+helper.add_aggregation("$map.name$", BCCHelper.$map.aggtype$)
+}$
+$hists:{hist|
+helper.add_aggregation("$hist.name$", BCCHelper.$hist.aggtype$)
+}$
+$keys:{key|
+helper.add_key_type("$key.name$", BCCHelper.$key.keytype$)
+}$
+
+while (1):
+    try:
+        sleep(1)
+    except KeyboardInterrupt:
+        exit()
+
+    helper.printall()

--- a/analytics-collectors/zio.st
+++ b/analytics-collectors/zio.st
@@ -1,0 +1,153 @@
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+from bcc import BPF
+from time import sleep
+from time import time
+import datetime
+import ctypes as ct
+import os
+import sys
+from bcchelper import BCCHelper
+
+# BPF txg program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/bpf_common.h>
+#include <uapi/linux/bpf.h>
+#include "/opt/delphix/server/etc/bcc_helper.h"
+#include <sys/zio.h>
+#include <sys/fs/zfs.h>
+
+// Structure to hold thread local data
+#define OP_NAME_LEN 6
+typedef struct {
+    u64 ts;
+} zio_data_t;
+
+// Key structure for scalar aggegations maps
+typedef struct {
+    u64  t;
+    $keys:{key| $key.declaration$
+    }$
+    u64  cpuid;
+} zio_key_t;
+
+HIST_KEY(zio_hist_key_t, zio_key_t);
+
+BPF_HASH(zio_base_data, zio_t *, zio_data_t);
+$maps:{map|
+BPF_HASH($map.name$, zio_key_t, $map.type$);
+}$
+$hists:{hist|
+BPF_HASH($hist.name$, zio_hist_key_t, u64);
+}$
+
+// Probe functions to initialize thread local data
+int vdev_queue_issue_return(struct pt_regs *ctx)
+{
+    zio_data_t data = {};
+    data.ts = bpf_ktime_get_ns();
+    zio_t *zio = (zio_t *)PT_REGS_RC(ctx);
+    zio_base_data.update(&zio, &data);
+
+    return 0;
+}
+
+/*
+ * BCC won't allow an argument with an opname array indexed
+ * by a variable, like:
+ * __builtin_memcpy(&key.op, opname[zio->io_type], OP_NAME_LEN);
+ * BCC does allow this if statement.  It's in a function so that
+ * it can be used easily by the template code with no
+ * references to the key.op if the op axis is not active.
+ */
+static void update_op(char **opstr, int type) {
+    if (type == ZIO_TYPE_READ)
+        __builtin_memcpy(opstr, "read", OP_NAME_LEN);
+    else if (type == ZIO_TYPE_WRITE)
+        __builtin_memcpy(opstr, "write", OP_NAME_LEN);
+    else if (type == ZIO_TYPE_FREE)
+        __builtin_memcpy(opstr, "free", OP_NAME_LEN);
+    else if (type == ZIO_TYPE_CLAIM)
+        __builtin_memcpy(opstr, "claim", OP_NAME_LEN);
+    else if (type == ZIO_TYPE_IOCTL)
+        __builtin_memcpy(opstr, "ioctl", OP_NAME_LEN);
+    else
+        __builtin_memcpy(opstr, "null", OP_NAME_LEN);
+}
+
+int vdev_queue_done(struct pt_regs *ctx, zio_t *zio)
+{
+    u64 ts = bpf_ktime_get_ns();
+    zio_data_t *data = zio_base_data.lookup(&zio);
+    zio_key_t key = {};
+    u64 delta;
+    u64 iosize = zio->io_size;
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    delta = ts - data->ts;
+    key.t = ts / $collection_period_in_ns$;
+    key.cpuid = bpf_get_smp_processor_id();
+    $keys:{key| $key.collect$
+    }$
+
+    $maps:{map|
+        $map.aggregation$;
+    }$
+
+    zio_hist_key_t hist_key = {};
+    hist_key.agg_key = key;
+
+    $hists:{hist|
+        hist_key.slot = $hist.slot$;
+        $hist.name$.increment(hist_key);
+    }$
+
+    zio_base_data.delete(&zio);
+    return 0;
+}
+
+
+"""
+
+def zio_key_equals(key1, key2):
+    return key1.t == key2.t \\
+           $keys:{key| and key1.$key.name$ == key2.$key.name$ \\
+           }$
+
+KVER = os.popen('uname -r').read().rstrip()
+b = BPF(text=bpf_text, cflags=["-include",
+                               "/usr/src/zfs-" + KVER + "/zfs_config.h",
+                               "-I/usr/src/zfs-" + KVER + "/include/",
+                               "-I/usr/src/zfs-" + KVER + "/include/os/linux/spl",
+                               "-I/usr/src/zfs-" + KVER + "/include/os/linux/kernel",
+                               "-I/usr/src/zfs-" + KVER + "/include/os/linux/zfs"])
+
+b.attach_kretprobe(event="vdev_queue_io_to_issue", fn_name="vdev_queue_issue_return")
+b.attach_kprobe(event="vdev_queue_io_done", fn_name="vdev_queue_done")
+
+helper = BCCHelper(b, zio_key_equals, BCCHelper.ANALYTICS_PRINT_MODE)
+$maps:{map|
+helper.add_aggregation("$map.name$", BCCHelper.$map.aggtype$)
+}$
+$hists:{hist|
+helper.add_aggregation("$hist.name$", BCCHelper.$hist.aggtype$)
+}$
+$keys:{key|
+helper.add_key_type("$key.name$", BCCHelper.$key.keytype$)
+}$
+
+while (1):
+    try:
+        sleep(1)
+    except KeyboardInterrupt:
+        exit()
+
+    helper.printall()

--- a/analytics-collectors/zpl.st
+++ b/analytics-collectors/zpl.st
@@ -1,0 +1,201 @@
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+from bcc import BPF
+from time import sleep
+from time import time
+import datetime
+import ctypes as ct
+import os
+import sys
+from bcchelper import BCCHelper
+
+# BPF txg program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/bpf_common.h>
+#include <uapi/linux/bpf.h>
+#include "/opt/delphix/server/etc/bcc_helper.h"
+
+#include <sys/uio.h>
+
+// Definitions for this script
+#define READ_STR "read"
+#define WRITE_STR "write"
+#define SYNC_WRITE  1
+#define ASYNC_WRITE 0
+#define CACHED_READ 1
+#define NONCACHED_READ 0
+#define AXIS_NOT_APPLICABLE -1
+
+// Structure to hold thread local data
+#define OP_NAME_LEN 6
+typedef struct {
+    u64 ts;
+    u64 size;
+    int sync;
+    int cached;
+} zpl_data_t;
+
+// Key structure for scalar aggegations maps
+typedef struct {
+    u64  t;
+    $keys:{key| $key.declaration$
+    }$
+    u32  cpuid;
+} zpl_key_t;
+
+HIST_KEY(zpl_hist_key_t, zpl_key_t);
+
+BPF_HASH(zpl_base_data, u32, zpl_data_t);
+$maps:{map|
+BPF_HASH($map.name$, zpl_key_t, $map.type$);
+}$
+$hists:{hist|
+BPF_HASH($hist.name$, zpl_hist_key_t, u64);
+}$
+
+// Probe functions to initialize thread local data
+int zfs_read_start(struct pt_regs *ctx, void *inode, uio_t *uio)
+{
+
+    u32 pid = bpf_get_current_pid_tgid();
+    zpl_data_t data = {};
+    data.ts = bpf_ktime_get_ns();
+    data.size = uio->uio_resid;
+    data.sync = AXIS_NOT_APPLICABLE; // Only applies to writes
+    data.cached = CACHED_READ; // Assume cache hit, misses detected
+    zpl_base_data.update(&pid, &data);
+    return 0;
+}
+
+// Probe functions to initialize thread local data
+int zfs_write_start(struct pt_regs *ctx, void *inode, uio_t *uio)
+{
+
+    u32 pid = bpf_get_current_pid_tgid();
+    zpl_data_t data = {};
+    data.ts = bpf_ktime_get_ns();
+    data.size = uio->uio_resid;
+    data.sync = ASYNC_WRITE; // Assume async write, sync writes detected
+    data.cached = AXIS_NOT_APPLICABLE; // Only applies to reads
+    zpl_base_data.update(&pid, &data);
+    return 0;
+}
+
+int zpl_cache_miss(struct pt_regs *ctx)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    zpl_data_t *data = zpl_base_data.lookup(&pid);
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    data->cached = NONCACHED_READ;
+
+    return 0;
+}
+
+int zil_commit_start(struct pt_regs *ctx)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    zpl_data_t *data = zpl_base_data.lookup(&pid);
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    data->sync = SYNC_WRITE;
+    return 0;
+}
+
+// Perform aggregations
+static int zpl_aggregate_data(u64 ts, char *opstr)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    zpl_data_t *data = zpl_base_data.lookup(&pid);
+    u64 delta;
+
+    if (data == 0) {
+        return 0;   // missed issue
+    }
+
+    delta = ts - data->ts;
+
+    zpl_key_t key = {};
+    $keys:{key| $key.collect$
+    }$
+    key.t = ts / $collection_period_in_ns$;
+    key.cpuid = bpf_get_smp_processor_id();
+
+    $maps:{map|
+        $map.aggregation$;
+    }$
+
+    zpl_hist_key_t hist_key = {};
+    hist_key.agg_key = key;
+
+    $hists:{hist|
+        hist_key.slot = $hist.slot$;
+        $hist.name$.increment(hist_key);
+    }$
+
+    zpl_base_data.delete(&pid);
+    return 0;
+}
+
+// Probe functions to aggregate data
+int zfs_read_done(struct pt_regs *ctx)
+{
+    u64 ts = bpf_ktime_get_ns();
+    return zpl_aggregate_data(ts, READ_STR);
+}
+
+int zfs_write_done(struct pt_regs *ctx)
+{
+    u64 ts = bpf_ktime_get_ns();
+    return zpl_aggregate_data(ts, WRITE_STR);
+}
+
+"""
+
+
+def zpl_key_equals(key1, key2):
+    return key1.t == key2.t \\
+           $keys:{key| and key1.$key.name$ == key2.$key.name$ \\
+           }$
+
+KVER = os.popen('uname -r').read().rstrip()
+b = BPF(text=bpf_text,
+        cflags=["-I/usr/src/zfs-" + KVER + "/include/os/linux/spl"])
+
+b.attach_kprobe(event="zfs_read", fn_name="zfs_read_start")
+b.attach_kprobe(event="zfs_write", fn_name="zfs_write_start")
+b.attach_kretprobe(event="zfs_read", fn_name="zfs_read_done")
+b.attach_kretprobe(event="zfs_write", fn_name="zfs_write_done")
+b.attach_kprobe(event="trace_zfs_arc__miss", fn_name="zpl_cache_miss")
+b.attach_kprobe(event="trace_zfs_blocked__read", fn_name="zpl_cache_miss")
+b.attach_kprobe(event="zil_commit", fn_name="zil_commit_start")
+
+helper = BCCHelper(b, zpl_key_equals, BCCHelper.ANALYTICS_PRINT_MODE)
+$maps:{map|
+helper.add_aggregation("$map.name$", BCCHelper.$map.aggtype$)
+}$
+$hists:{hist|
+helper.add_aggregation("$hist.name$", BCCHelper.$hist.aggtype$)
+}$
+$keys:{key|
+helper.add_key_type("$key.name$", BCCHelper.$key.keytype$)
+}$
+
+while (1):
+    try:
+        sleep(1)
+    except KeyboardInterrupt:
+        exit()
+
+    helper.printall()


### PR DESCRIPTION
These are the back-end analytics collectors that the virtualization engine uses along with the `bcchelper.py` file that contains their python glue. They are not usable as-is since they're Java string templates, and are here merely for reference. In the future, it would be desirable to merge these with the performance playbook scripts so that we don't have two sets of similar scripts.