### PR TITLE
Run flake8 against pull requests

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,19 @@
+name: Python Lint
+
+on: [pull_request, push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 2.7
+    - name: flake8
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+        flake8 . --show-source --statistics


### PR DESCRIPTION
This adds a Github action to run `flake8` against pull requests. I tested by adding the action to my fork, submitting a pull request to my fork with style errors, and confirming that the action failed. I then fixed the violations and confirmed that the action succeeded.