### PR TITLE
DLPX-67298 kprobes are leaked when delphix-mgmt restarts

### DIFF
--- a/lib/bcchelper.py
+++ b/lib/bcchelper.py
@@ -7,6 +7,7 @@
 from time import time
 import logging
 import re
+import signal
 
 """ BCC Helper
 This module contains the BCCHelper class to aid in writing BCC Tracing
@@ -124,6 +125,15 @@ class BCCHelper:
         logging.basicConfig(level=logging.CRITICAL,
                             format='%(asctime)s - %(levelname)s - %(message)s')
         self.logger = logging.getLogger()
+
+        #
+        # Try to run atexit handlers if we are killed by a signal. BCC
+        # registers handlers to detach kprobes, and if these aren't run the
+        # probes are leaked.
+        #
+        def _handler(signum, frame):
+            exit(1)
+        signal.signal(signal.SIGTERM, _handler)
 
     @staticmethod
     def isHistogram(agg):


### PR DESCRIPTION
The lifetime of kprobe objects in the kernel is not tied to that of the process that creates them. BCC handles this by registering a Python 'atexit' handler which detatches the probes, allowing them to be cleaned up by the kernel. When the management stack restarts, however, the analytics BCC programs are killed with a SIGTERM by systemd. The python process does not have a signal handler for this signal by default, so the process is killed without the 'atexit' handlers being run.

A simple way to resolve this issue is to install a signal handler which forces the 'atexit' handlers to be run before exiting.

**Testing:**
I tested this by running an `estat` command, killing it with a SIGTERM, and confirming that the kprobes were cleaned up by looking at `/sys/kernel/debug/tracing/kprobe_profile`

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2515/console