### PR TITLE
Fix backend io collector post 5.x kernel upgrade

### DIFF
--- a/bpf/estat/backend-io.c
+++ b/bpf/estat/backend-io.c
@@ -30,7 +30,6 @@ typedef struct {
 
 BPF_HASH(io_base_data, u64, io_data_t);
 
-// @@ kprobe|blk_start_request|disk_io_start
 // @@ kprobe|blk_mq_start_request|disk_io_start
 int
 disk_io_start(struct pt_regs *ctx, struct request *reqp)

--- a/bpf/estat/backend-io.c
+++ b/bpf/estat/backend-io.c
@@ -30,6 +30,7 @@ typedef struct {
 
 BPF_HASH(io_base_data, u64, io_data_t);
 
+// @@ kprobe|blk_start_request|disk_io_start
 // @@ kprobe|blk_mq_start_request|disk_io_start
 int
 disk_io_start(struct pt_regs *ctx, struct request *reqp)

--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -128,6 +128,8 @@ int disk_io_done(struct pt_regs *ctx, struct request *reqp)
 """
 b = BPF(text=bpf_text)
 
+if BPF.get_kprobe_functions(b'blk_start_request'):
+    b.attach_kprobe(event="blk_start_request", fn_name="disk_io_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="disk_io_start")
 b.attach_kprobe(event="blk_account_io_completion", fn_name="disk_io_done")
 

--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -128,7 +128,6 @@ int disk_io_done(struct pt_regs *ctx, struct request *reqp)
 """
 b = BPF(text=bpf_text)
 
-b.attach_kprobe(event="blk_start_request", fn_name="disk_io_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="disk_io_start")
 b.attach_kprobe(event="blk_account_io_completion", fn_name="disk_io_done")
 

--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -412,11 +412,12 @@ for line in input_text.splitlines():
                 line + "'")
         probe_type = probe_spec[0]
         if probe_type == "kprobe":
-	    if BPF.get_kprobe_functions(probe_spec[1]):
+            if BPF.get_kprobe_functions(probe_spec[1]):
                 b.attach_kprobe(event=probe_spec[1], fn_name=probe_spec[2])
                 probes.add("p_" + probe_spec[1] + "_bcc_" + str(os.getpid()))
             else:
-                print("WARNING: {}: {} - not found".format(probe_type, probe_spec[1]))
+                print("WARNING: {}: {} - not found"
+                      .format(probe_type, probe_spec[1]))
         elif probe_type == "kretprobe":
             b.attach_kretprobe(event=probe_spec[1], fn_name=probe_spec[2],
                                maxactive=MAXACTIVE)

--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -412,8 +412,11 @@ for line in input_text.splitlines():
                 line + "'")
         probe_type = probe_spec[0]
         if probe_type == "kprobe":
-            b.attach_kprobe(event=probe_spec[1], fn_name=probe_spec[2])
-            probes.add("p_" + probe_spec[1] + "_bcc_" + str(os.getpid()))
+	    if BPF.get_kprobe_functions(probe_spec[1]):
+                b.attach_kprobe(event=probe_spec[1], fn_name=probe_spec[2])
+                probes.add("p_" + probe_spec[1] + "_bcc_" + str(os.getpid()))
+            else:
+                print("WARNING: {}: {} - not found".format(probe_type, probe_spec[1]))
         elif probe_type == "kretprobe":
             b.attach_kretprobe(event=probe_spec[1], fn_name=probe_spec[2],
                                maxactive=MAXACTIVE)


### PR DESCRIPTION
Upgrade to linux kernel 5.x breaks the backend IO collector, using `estat` or `stbtrace` fails with 
```Failed to attach BPF program disk_io_start to kprobe blk_start_request```

This is a quick fix, verified on latest trunk VM using 5.x kernel.
