### PR TITLE
Fix backend io collector post 5.x kernel upgrade (#18)

### DIFF
--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -128,7 +128,8 @@ int disk_io_done(struct pt_regs *ctx, struct request *reqp)
 """
 b = BPF(text=bpf_text)
 
-b.attach_kprobe(event="blk_start_request", fn_name="disk_io_start")
+if BPF.get_kprobe_functions(b'blk_start_request'):
+    b.attach_kprobe(event="blk_start_request", fn_name="disk_io_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="disk_io_start")
 b.attach_kprobe(event="blk_account_io_completion", fn_name="disk_io_done")
 

--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -412,8 +412,12 @@ for line in input_text.splitlines():
                 line + "'")
         probe_type = probe_spec[0]
         if probe_type == "kprobe":
-            b.attach_kprobe(event=probe_spec[1], fn_name=probe_spec[2])
-            probes.add("p_" + probe_spec[1] + "_bcc_" + str(os.getpid()))
+            if BPF.get_kprobe_functions(probe_spec[1]):
+                b.attach_kprobe(event=probe_spec[1], fn_name=probe_spec[2])
+                probes.add("p_" + probe_spec[1] + "_bcc_" + str(os.getpid()))
+            else:
+                print("WARNING: {}: {} - not found"
+                      .format(probe_type, probe_spec[1]))
         elif probe_type == "kretprobe":
             b.attach_kretprobe(event=probe_spec[1], fn_name=probe_spec[2],
                                maxactive=MAXACTIVE)


### PR DESCRIPTION
Heres the PR against `6.0/release` to fix backend io collector post 5.x kernel upgrade.
