### PR TITLE
Fix ZPL Collectors after ZFS changes to sync flags and include files

### DIFF
--- a/bpf/estat/zpl.c
+++ b/bpf/estat/zpl.c
@@ -57,7 +57,7 @@ zfs_read_write_entry(io_info_t *info, struct inode *ip, uio_t *uio, int flags)
 	info->start_time = bpf_ktime_get_ns();
 	info->bytes = uio->uio_resid;
 	info->is_sync =
-	    z_os->os_sync == ZFS_SYNC_ALWAYS || (flags & (FSYNC | FDSYNC));
+	    z_os->os_sync == ZFS_SYNC_ALWAYS || (flags & (O_SYNC | O_DSYNC));
 
 	u32 tid = bpf_get_current_pid_tgid();
 	io_info_t *infop = io_info_map.lookup(&tid);

--- a/bpf/stbtrace/zpl.st
+++ b/bpf/stbtrace/zpl.st
@@ -172,8 +172,12 @@ int zfs_write_done(struct pt_regs *ctx)
 
 """
 KVER = os.popen('uname -r').read().rstrip()
-b = BPF(text=bpf_text,
-        cflags=["-I/usr/src/zfs-" + KVER + "/include/spl"])
+b = BPF(text=bpf_text, cflags=["-include",
+                               "/usr/src/zfs-" + KVER + "/zfs_config.h",
+                               "-include",
+                               "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
+                               "-I/usr/src/zfs-" + KVER + "/include/",
+                               "-I/usr/src/zfs-" + KVER + "/include/spl/"])
 
 b.attach_kprobe(event="zfs_read", fn_name="zfs_read_start")
 b.attach_kprobe(event="zfs_write", fn_name="zfs_write_start")

--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -383,6 +383,8 @@ if dump_bpf:
 KVER = os.popen('uname -r').read().rstrip()
 cflags = ["-include",
           "/usr/src/zfs-" + KVER + "/zfs_config.h",
+          "-include",
+          "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
           "-I/usr/src/zfs-" + KVER + "/include/",
           "-I/usr/src/zfs-" + KVER + "/include/spl"]
 if script_arg:


### PR DESCRIPTION
ZFS dropped FSYNC and FDSYNC  and zfs_write now checks for O_SYNC and OD_SYNC.  Additionally, the include file in zfs_headers changed enough to cause some multiple definitions and some missing definitions. 

I ran the zpl collector for estat and stbtrace  on 4.15 and 5.0 kernels:

5.0.0-36-generic
```
$ uname -a
Linux brad-zpl.dcenter 5.0.0-36-generic #39~18.04.1-Ubuntu SMP Tue Nov 12 11:09:50 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
$ sudo ./estat.py zpl -a rpool 4
12/05/19 - 23:29:31 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                         zfs_read async, 
value range                 count ------------- Distribution ------------- 
[0, 10)                        51 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@  
[10, 20)                        2 |@                                       

   microseconds                                        zfs_write async, 
value range                 count ------------- Distribution ------------- 
[0, 10)                         5 |@@@                                     
[10, 20)                       27 |@@@@@@@@@@@@@@@@@@                      
[20, 30)                       12 |@@@@@@@@                                
[30, 40)                        4 |@@@                                     
[50, 60)                        4 |@@@                                     
[60, 70)                        2 |@                                       
[70, 80)                        1 |@                                       
[100, 200)                      3 |@@                                      

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
 zfs_read async,                             13                2                9                0
 zfs_write async,                            14               27              627              176


                                       iops(/s)  throughput(k/s)
 total                                       27              176

$ sudo ./stbtrace.py zpl
{"t":"1575588610", "cached":"-1", "sync":"0", "op":"write", "count":"3", "throughput":"24576", "avgLatency":"44372", "latency":"{30000,1},{60000,2}", "size":"{16383,3}"}

{"t":"1575588611", "cached":"-1", "sync":"0", "op":"write", "count":"1", "throughput":"16384", "avgLatency":"579812", "latency":"{600000,1}", "size":"{32767,1}"}

{"t":"1575588611", "cached":"-1", "sync":"0", "op":"write", "count":"3", "throughput":"24576", "avgLatency":"43804", "latency":"{30000,1},{60000,2}", "size":"{16383,3}"}

{"t":"1575588612", "cached":"-1", "sync":"0", "op":"write", "count":"1", "throughput":"8192", "avgLatency":"56616", "latency":"{60000,1}", "size":"{16383,1}"}

{"t":"1575588612", "cached":"-1", "sync":"0", "op":"write", "count":"4", "throughput":"40960", "avgLatency":"65239", "latency":"{30000,1},{40000,1},{90000,1},{200000,1}", "size":"{16383,3},{32767,1}"}

{"t":"1575588613", "cached":"1", "sync":"-1", "op":"read", "count":"25", "throughput":"14712", "avgLatency":"2463", "latency":"{10000,25}", "size":"{31,2},{127,2},{255,2},{511,4},{1023,15}"}
``` 

4.15.0-1054-aws
```
$ uname -a
Linux ip-10-110-197-212 4.15.0-1054-aws #56-Ubuntu SMP Thu Nov 7 16:15:59 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
$ sudo ./estat.py zpl -a rpool 4
12/05/19 - 23:30:52 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                         zfs_read async, 
value range                 count ------------- Distribution ------------- 
[0, 10)                        52 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ 
[10, 20)                        1 |@                                       

   microseconds                                        zfs_write async, 
value range                 count ------------- Distribution ------------- 
[0, 10)                        30 |@@@@@@@@@@@@@@@@@@@@                    
[10, 20)                        3 |@@                                      
[20, 30)                        8 |@@@@@                                   
[30, 40)                        2 |@                                       
[40, 50)                       11 |@@@@@@@                                 
[50, 60)                        3 |@@                                      
[60, 70)                        2 |@                                       

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
 zfs_read async,                             13                2                6                0
 zfs_write async,                            14               22              347              184


                                       iops(/s)  throughput(k/s)
 total                                       28              184


$ sudo ./stbtrace.py zpl
{"t":"1575588676", "cached":"-1", "sync":"0", "op":"write", "count":"5", "throughput":"40960", "avgLatency":"39974", "latency":"{30000,1},{40000,1},{50000,2},{60000,1}", "size":"{16383,5}"}

{"t":"1575588677", "cached":"-1", "sync":"0", "op":"write", "count":"5", "throughput":"49152", "avgLatency":"35089", "latency":"{30000,2},{40000,1},{50000,2}", "size":"{16383,4},{32767,1}"}

{"t":"1575588678", "cached":"-1", "sync":"0", "op":"write", "count":"5", "throughput":"40960", "avgLatency":"39141", "latency":"{30000,1},{40000,1},{50000,3}", "size":"{16383,5}"}

{"t":"1575588679", "cached":"1", "sync":"-1", "op":"read", "count":"25", "throughput":"14712", "avgLatency":"1897", "latency":"{10000,25}", "size":"{31,2},{127,2},{255,2},{511,4},{1023,15}"}

{"t":"1575588679", "cached":"-1", "sync":"0", "op":"write", "count":"19", "throughput":"43286", "avgLatency":"20236", "latency":"{10000,9},{20000,3},{30000,1},{40000,2},{50000,3},{60000,1}", "size":"{127,7},{255,4},{511,3},{16383,5}"}

{"t":"1575588680", "cached":"-1", "sync":"0", "op":"write", "count":"6", "throughput":"57344", "avgLatency":"38454", "latency":"{30000,2},{40000,1},{50000,2},{60000,1}", "size":"{16383,5},{32767,1}"}

{"t":"1575588681", "cached":"-1", "sync":"0", "op":"write", "count":"5", "throughput":"49152", "avgLatency":"37298", "latency":"{30000,1},{40000,1},{50000,3}", "size":"{16383,4},{32767,1}"}

{"t":"1575588682", "cached":"-1", "sync":"0", "op":"write", "count":"5", "throughput":"40960", "avgLatency":"40510", "latency":"{30000,1},{50000,4}", "size":"{16383,5}"}

^C
```