### PR TITLE
Throughput values are not normalized

### DIFF
--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -86,7 +86,6 @@ help_msg += """
       -z/-Z     enable/disable size histograms (default: off)
       -q/-Q     enable/disable latency histograms by size (default: off)
       -y/-Y     enable/disable the summary output (default: on)
-      -n/-N     enable/disable normalizing summary by time (default: on)
       -t/-T     enable/disable emitting the summary total (default: on)
       -d LEVEL  set BCC debug level
       -e        emit the resulting eBPF script without executing it
@@ -144,7 +143,6 @@ setattr(args, "lat_hist", False)
 setattr(args, "size_hist", False)
 setattr(args, "latsize_hist", False)
 setattr(args, "summary", True)
-setattr(args, "normalize", True)
 setattr(args, "total", True)
 
 #
@@ -182,7 +180,6 @@ for opt, arg in opts:
                     '-z': "size_hist",
                     '-q': "latsize_hist",
                     '-y': "summary",
-                    '-n': "normalize",
                     '-t': "total"}
         if opt in switches:
             setattr(args, switches[opt], True)
@@ -484,9 +481,10 @@ if monitor:
             ds__delta = ds__end - ds__start
             if not accum:
                 ds__start = ds__end
-            if args.summary and args.normalize:
-                helper1.normalize("ops", ds__delta // 1000000000)
-                helper3.normalize("opst", ds__delta // 1000000000)
+            helper1.normalize("ops", ds__delta // 1000000000)
+            helper1.normalize("data", ds__delta // 1000000000)
+            helper3.normalize("opst", ds__delta // 1000000000)
+            helper3.normalize("datat", ds__delta // 1000000000)
             clear_data = not accum
             if args.latsize_hist:
                 helper2.printall(clear_data)
@@ -505,9 +503,10 @@ else:
         pass
     try:
         ds__delta = int(os.popen("date +%s%N").readlines()[0]) - ds__start
-        if args.summary and args.normalize:
-            helper1.normalize("ops", ds__delta // 1000000000)
-            helper3.normalize("opst", ds__delta // 1000000000)
+        helper1.normalize("ops", ds__delta // 1000000000)
+        helper1.normalize("data", ds__delta // 1000000000)
+        helper3.normalize("opst", ds__delta // 1000000000)
+        helper3.normalize("datat", ds__delta // 1000000000)
         if args.latsize_hist:
             helper2.printall()
         if args.lat_hist or args.size_hist or args.summary:


### PR DESCRIPTION
closes #23

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: 23


## What is the new behavior?
Throughput now normalized so that it is truly kb/s.   

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Here is some output showing the throughput correctly reported: 
```
$ sudo ./cmd/estat.py zio  1
...
                                      iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
 write, syncw                                 8             2143          5498292              120

                                       iops(/s)  throughput(k/s)
 total                                        8              120

$ sudo ./cmd/estat.py zio  10
...
                                      iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
 write, asyncw                               23             1938          5616501              105
 write, syncw                                11             7970          9586502              144


                                       iops(/s)  throughput(k/s)
 total                                       34              249

$ sudo ./cmd/estat.py zio -N 10
...
                                      iops(/s)  avg latency(us)       stddev(us)    throughput(k)
 write, asyncw                              233             1397          3168196             1015
 write, syncw                               116            14535         21605727             1950


                                       iops(/s)    throughput(k)
 total                                      349             2965


```


