### PR TITLE
Use copy of bcc_helper.h from performance-diagnositics

### DIFF
--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -24,14 +24,13 @@ from bcchelper import BCCHelper
 
 
 # BPF disk io program
-bpf_text = """
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <linux/blkdev.h>
 #include <linux/blk_types.h>
 #include <uapi/linux/bpf.h>
-#include "/opt/delphix/server/etc/bcc_helper.h"
-
 
 // Definitions for this script
 #define READ_STR "read"

--- a/bpf/stbtrace/iscsi.st
+++ b/bpf/stbtrace/iscsi.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -23,11 +23,11 @@ sys.path.append(base_dir + 'lib/')
 from bcchelper import BCCHelper
 
 # BPF txg program
-bpf_text = """
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
-#include "/opt/delphix/server/etc/bcc_helper.h"
 
 #include "target/iscsi/iscsi_target_core.h"
 

--- a/bpf/stbtrace/nfs.st
+++ b/bpf/stbtrace/nfs.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -23,12 +23,12 @@ sys.path.append(base_dir + 'lib/')
 from bcchelper import BCCHelper
 
 # BPF txg program
-bpf_text = """
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
 #include <linux/sunrpc/svc.h>
-#include "/opt/delphix/server/etc/bcc_helper.h"
 
 
 // nfsd4 definitions from fs/nfsd/xdr4.h

--- a/bpf/stbtrace/vfs.st
+++ b/bpf/stbtrace/vfs.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -23,11 +23,11 @@ sys.path.append(base_dir + 'lib/')
 from bcchelper import BCCHelper
 
 # BPF txg program
-bpf_text = """
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
-#include "/opt/delphix/server/etc/bcc_helper.h"
 
 // Definitions for this script
 #define READ_STR "read"

--- a/bpf/stbtrace/zio.st
+++ b/bpf/stbtrace/zio.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -23,11 +23,11 @@ sys.path.append(base_dir + 'lib/')
 from bcchelper import BCCHelper
 
 # BPF txg program
-bpf_text = """
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
-#include "/opt/delphix/server/etc/bcc_helper.h"
 #include <sys/zio.h>
 #include <sys/fs/zfs.h>
 

--- a/bpf/stbtrace/zpl.st
+++ b/bpf/stbtrace/zpl.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -23,11 +23,11 @@ sys.path.append(base_dir + 'lib/')
 from bcchelper import BCCHelper
 
 # BPF txg program
-bpf_text = """
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
-#include "/opt/delphix/server/etc/bcc_helper.h"
 
 #include <sys/uio.h>
 

--- a/lib/bcchelper.py
+++ b/lib/bcchelper.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, 2019 Delphix. All rights reserved.
+# Copyright 2018, 2020 Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -16,7 +16,7 @@ Guide.
 https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#1-bpf
 
 Defitions for C helper routines and macros are in
-/opt/delphix/server/etc/bcc_helper.h
+lib/bcc_helper.h
 
 BCC Helper focuses are printing out data from a set of tracing aggregations.
 There are three supported scalar types of aggregations(count, sum, and


### PR DESCRIPTION
Some of our scripts rely on the copy of bcc_helper.h from the app-gate. I checked that the contents of the copy in the app-gate and the copy in this repo are identical, modulo some formatting, and then switch all the scripts to rely on the copy here.

**Testing**
I removed the copy bcc_helper.h installed by the app-gate and ran each collector to make sure it compiled and produced reasonable output.

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2681/