### PR TITLE
ZIL fixes

### DIFF
--- a/bpf/standalone/zil.py
+++ b/bpf/standalone/zil.py
@@ -25,16 +25,15 @@ from time import sleep, strftime
 import argparse
 import sys
 import os
-repo_lib_dir = os.path.dirname(__file__) + "/../../lib/"
-if os.path.exists(repo_lib_dir + "bcchelper.py"):
-    sys.path.append(repo_lib_dir)
-else:
-    sys.path.append("/usr/share/performance-diagnostics/lib/")
-from bcchelper import BCCHelper  # noqa 
+base_dir = os.path.dirname(__file__) + "/../../"
+if not os.path.exists(base_dir + "lib/bcchelper.py"):
+    base_dir = "/usr/share/performance-diagnostics/"
+sys.path.append(base_dir + 'lib/')
+from bcchelper import BCCHelper   # noqa: E402
 
 # define BPF program
-bpf_text = """
-#include "/opt/delphix/server/etc/bcc_helper.h"
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
@@ -132,7 +131,7 @@ uio_t *uio, int ioflag)
                 return 0;
 
     info.alloc_count = 0;
-    info.sync = ioflag & (FSYNC | FDSYNC) ||
+    info.sync = ioflag & (O_SYNC | O_DSYNC) ||
             zfsvfs->z_os->os_sync == ZFS_SYNC_ALWAYS;
     zil_info_map.update(&tid, &info);
     return 0;


### PR DESCRIPTION
While doing some other testing, I noticed that a couple things in the `zil` script needed fixing:

 - The path to the bcc helper needs to be updated, similar to what was done for the stbtrace programs in #27.
 - The flags used to determine if a write is synchronous or not need to be updated, similar to what was done in #21.

ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2697/