### PR TITLE
Compilation failures due to fentry issue

### DIFF
--- a/bpf/standalone/zil.py
+++ b/bpf/standalone/zil.py
@@ -259,7 +259,8 @@ b = BPF(text=bpf_text,
                 "-I/usr/src/zfs-" + KVER + "/include/",
                 "-I/usr/src/zfs-" + KVER + "/include/spl",
                 "-I/usr/src/zfs-" + KVER + "/include/",
-                "-I/usr/src/zfs-" + KVER + "/include/linux"])
+                "-I/usr/src/zfs-" + KVER + "/include/linux",
+                "-DCC_USING_FENTRY"])
 
 b.attach_kprobe(event="zfs_write", fn_name="zfs_write_entry")
 b.attach_kretprobe(event="zfs_write", fn_name="zfs_write_return")

--- a/bpf/stbtrace/zio.st
+++ b/bpf/stbtrace/zio.st
@@ -130,7 +130,8 @@ b = BPF(text=bpf_text, cflags=["-include",
                                "/usr/src/zfs-" + KVER + "/zfs_config.h",
                                "-I/usr/src/zfs-" + KVER + "/include/",
                                "-I/usr/src/zfs-" + KVER + "/include/spl/",
-                               "-I/usr/src/zfs-" + KVER + "/include/linux"])
+                               "-I/usr/src/zfs-" + KVER + "/include/linux",
+                               "-DCC_USING_FENTRY"])
 
 b.attach_kretprobe(event="vdev_queue_io_to_issue",
                    fn_name="vdev_queue_issue_return")

--- a/bpf/stbtrace/zpl.st
+++ b/bpf/stbtrace/zpl.st
@@ -178,7 +178,8 @@ b = BPF(text=bpf_text,
                 "-include",
                 "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
                 "-I/usr/src/zfs-" + KVER + "/include/",
-                "-I/usr/src/zfs-" + KVER + "/include/spl/"])
+                "-I/usr/src/zfs-" + KVER + "/include/spl/",
+                "-DCC_USING_FENTRY"])
 
 b.attach_kprobe(event="zfs_read", fn_name="zfs_read_start")
 b.attach_kprobe(event="zfs_write", fn_name="zfs_write_start")

--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -386,7 +386,8 @@ cflags = ["-include",
           "-include",
           "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
           "-I/usr/src/zfs-" + KVER + "/include/",
-          "-I/usr/src/zfs-" + KVER + "/include/spl"]
+          "-I/usr/src/zfs-" + KVER + "/include/spl",
+          "-DCC_USING_FENTRY"]
 if script_arg:
     cflags.append("-DOPTARG=\"" + script_arg + "\"")
 


### PR DESCRIPTION
Due to[ changes in ftrace.h](https://github.com/torvalds/linux/commit/562e14f72292249e52e6346a9e3a30be652b0cf6) the bcc C code fails to compile for scripts including zfs headers.  
For example:  
$ sudo ./estat.py zil
In file included from /virtual/main.c:8:
In file included from /usr/src/zfs-5.3.0-26-generic/include/sys/zfs_vfsops.h:29:
In file included from /usr/src/zfs-5.3.0-26-generic/include/sys/dataset_kstats.h:30:
In file included from /usr/src/zfs-5.3.0-26-generic/include/sys/aggsum.h:22:
In file included from /usr/src/zfs-5.3.0-26-generic/include/sys/zfs_context.h:57:
In file included from /usr/src/zfs-5.3.0-26-generic/include/spl/sys/sunddi.h:32:
In file included from /usr/src/zfs-5.3.0-26-generic/include/spl/sys/vnode.h:29:
In file included from include/linux/syscalls.h:85:
In file included from include/trace/syscall.h:7:
In file included from include/linux/trace_events.h:10:
In file included from include/linux/perf_event.h:49:
In file included from include/linux/ftrace.h:21:
./arch/x86/include/asm/ftrace.h:7:3: error: Compiler does not support fentry?
# error Compiler does not support fentry?
  ^
1 error generated.



