### PR TITLE
Invalid mem errors when using latest BCC

### DIFF
--- a/bpf/estat/backend-io.c
+++ b/bpf/estat/backend-io.c
@@ -15,9 +15,8 @@
 #define	READ_STR "read "
 #define	WRITE_STR "write "
 #define	OP_NAME_LEN 7
-#define	DEV_NAME_LEN 8
 #define	NAME_LENGTH (OP_NAME_LEN + 1)
-#define	AXIS_LENGTH (DEV_NAME_LEN + 1)
+#define	AXIS_LENGTH (DISK_NAME_LEN + 1)
 
 // Structure to hold thread local data
 typedef struct {
@@ -25,7 +24,7 @@ typedef struct {
 	unsigned int size;
 	unsigned int cmd_flags;
 	u32 err;
-	char device[DEV_NAME_LEN];
+	char device[DISK_NAME_LEN];
 } io_data_t;
 
 BPF_HASH(io_base_data, u64, io_data_t);
@@ -40,7 +39,7 @@ disk_io_start(struct pt_regs *ctx, struct request *reqp)
 	data.ts = bpf_ktime_get_ns();
 	data.cmd_flags = reqp->cmd_flags;
 	data.size = reqp->__data_len;
-	__builtin_memcpy(&data.device, diskp->disk_name, DEV_NAME_LEN);
+	bpf_probe_read_str(&data.device, DISK_NAME_LEN, diskp->disk_name);
 	io_base_data.update((u64 *) &reqp, &data);
 	return (0);
 }

--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -69,7 +69,7 @@ int disk_io_start(struct pt_regs *ctx, struct request *reqp)
     data.ts = bpf_ktime_get_ns();
     data.cmd_flags = reqp->cmd_flags;
     data.size = reqp->__data_len;
-    __builtin_memcpy(&data.device, diskp->disk_name, DISK_NAME_LEN);
+    bpf_probe_read_str(&data.device, DISK_NAME_LEN, diskp->disk_name);
     io_base_data.update((u64 *) &reqp, &data);
     return 0;
 }


### PR DESCRIPTION
When running with the latest version of BCC (not yet merged into our repo), we see the following error when running the io stbtrace/estat programs:
```
$ sudo estat backend-io -a rpool 5
bpf: Failed to load program: Permission denied
0: (79) r6 = *(u64 *)(r1 +112)
1: (7b) *(u64 *)(r10 -8) = r6
2: (b7) r7 = 0
3: (7b) *(u64 *)(r10 -16) = r7
4: (7b) *(u64 *)(r10 -24) = r7
5: (7b) *(u64 *)(r10 -48) = r7
6: (bf) r3 = r6
7: (07) r3 += 192
8: (bf) r1 = r10
9: (07) r1 += -48
10: (b7) r2 = 8
11: (85) call bpf_probe_read#4
12: (79) r8 = *(u64 *)(r10 -48)
13: (85) call bpf_ktime_get_ns#5
14: (7b) *(u64 *)(r10 -40) = r0
15: (63) *(u32 *)(r10 -48) = r7
16: (bf) r3 = r6
17: (07) r3 += 68
18: (bf) r1 = r10
19: (07) r1 += -48
20: (b7) r2 = 4
21: (85) call bpf_probe_read#4
22: (61) r1 = *(u32 *)(r10 -48)
23: (63) *(u32 *)(r10 -28) = r1
24: (07) r6 += 88
25: (63) *(u32 *)(r10 -48) = r7
26: (bf) r1 = r10
27: (07) r1 += -48
28: (b7) r2 = 4
29: (bf) r3 = r6
30: (85) call bpf_probe_read#4
31: (61) r1 = *(u32 *)(r10 -48)
32: (63) *(u32 *)(r10 -32) = r1
33: (61) r1 = *(u32 *)(r8 +12)
R8 invalid mem access 'inv'

HINT: The invalid mem access 'inv' error can happen if you try to dereference memory without first using bpf_probe_read() to copy it to the BPF stack. Sometimes the bpf_probe_read is automatic by the bcc rewriter, other times you'll need to be explicit.

Traceback (most recent call last):
  File "/usr/bin/estat", line 418, in <module>
    b.attach_kprobe(event=probe_spec[1], fn_name=probe_spec[2])
  File "/usr/lib/python3/dist-packages/bcc/__init__.py", line 656, in attach_kprobe
    fn = self.load_func(fn_name, BPF.KPROBE)
  File "/usr/lib/python3/dist-packages/bcc/__init__.py", line 397, in load_func
    (func_name, errstr))
Exception: Failed to load BPF program b'disk_io_start': Permission denied
```
I resolved these by switching to instances of string copying to use `bpf_probe_read_str` instead of `__builtin_memcpy`

### Testing
I tested by running each of the estat programs and stbtrace collectors, and making sure they compiled and produced output that looked reasonably correct when run.

