### PR TITLE
stbtrace should have nonzero exit code on failure  [Backport of #17 to 6.0.3.0]

### DIFF
--- a/cmd/stbtrace.py
+++ b/cmd/stbtrace.py
@@ -133,8 +133,12 @@ else:
 script = template.render()
 if args.bcc:
     print (script)
+    exit(0)
 else:
     try:
         exec(script)
-    except BaseException as e:
+    except KeyboardInterrupt:
+        exit(0)
+    except Exception as e:
         print (e)
+        exit(1)


### PR DESCRIPTION
Clean cherry-pick from master (commit 21b6666da2 ).

ab-pre-push:  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3433/

Needed for picking up the phython3 commit.