### PR TITLE
Compilation failures due to fentry issue [Backport of #33 to 6.0.3.0]

### DIFF
--- a/bpf/standalone/zil.py
+++ b/bpf/standalone/zil.py
@@ -260,7 +260,8 @@ b = BPF(text=bpf_text,
                 "-I/usr/src/zfs-" + KVER + "/include/",
                 "-I/usr/src/zfs-" + KVER + "/include/spl",
                 "-I/usr/src/zfs-" + KVER + "/include/",
-                "-I/usr/src/zfs-" + KVER + "/include/linux"])
+                "-I/usr/src/zfs-" + KVER + "/include/linux",
+                "-DCC_USING_FENTRY"])
 
 b.attach_kprobe(event="zfs_write", fn_name="zfs_write_entry")
 b.attach_kretprobe(event="zfs_write", fn_name="zfs_write_return")

--- a/bpf/stbtrace/zio.st
+++ b/bpf/stbtrace/zio.st
@@ -132,7 +132,8 @@ b = BPF(text=bpf_text, cflags=["-include",
                                "/usr/src/zfs-" + KVER + "/zfs_config.h",
                                "-I/usr/src/zfs-" + KVER + "/include/",
                                "-I/usr/src/zfs-" + KVER + "/include/spl/",
-                               "-I/usr/src/zfs-" + KVER + "/include/linux"])
+                               "-I/usr/src/zfs-" + KVER + "/include/linux",
+                               "-DCC_USING_FENTRY"])
 
 b.attach_kretprobe(event="vdev_queue_io_to_issue", fn_name="vdev_queue_issue_return")
 b.attach_kprobe(event="vdev_queue_io_done", fn_name="vdev_queue_done")

--- a/bpf/stbtrace/zpl.st
+++ b/bpf/stbtrace/zpl.st
@@ -173,7 +173,8 @@ int zfs_write_done(struct pt_regs *ctx)
 """
 KVER = os.popen('uname -r').read().rstrip()
 b = BPF(text=bpf_text,
-        cflags=["-I/usr/src/zfs-" + KVER + "/include/spl"])
+        cflags=["-I/usr/src/zfs-" + KVER + "/include/spl/",
+                "-DCC_USING_FENTRY"])
 
 b.attach_kprobe(event="zfs_read", fn_name="zfs_read_start")
 b.attach_kprobe(event="zfs_write", fn_name="zfs_write_start")

--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -394,7 +394,8 @@ KVER = os.popen('uname -r').read().rstrip()
 cflags = ["-include",
           "/usr/src/zfs-" + KVER + "/zfs_config.h",
           "-I/usr/src/zfs-" + KVER + "/include/",
-          "-I/usr/src/zfs-" + KVER + "/include/spl"]
+          "-I/usr/src/zfs-" + KVER + "/include/spl",
+          "-DCC_USING_FENTRY"]
 if script_arg:
     cflags.append("-DOPTARG=\"" + script_arg + "\"")
 


### PR DESCRIPTION
Clean cherry-pick of #33 

**Testing:**
ab-pre-push:  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3455/

On image from above ab-pre-push, spot checked various estat commands and verified analytic probes are working.  No longer seeing the `fentry` compiler errors.