### PR TITLE
DLPX-72430 Estat zil fails to run because of unknown types

### DIFF
--- a/bpf/standalone/zil.py
+++ b/bpf/standalone/zil.py
@@ -37,9 +37,7 @@ bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
-#include <sys/file.h>
-#include <sys/fs/zfs.h>
-#include <sys/zfs_vfsops.h>
+#include <sys/xvattr.h>
 #include <sys/zfs_znode.h>
 #include <sys/dmu_objset.h>
 #include <sys/spa_impl.h>
@@ -256,11 +254,10 @@ KVER = os.popen('uname -r').read().rstrip()
 b = BPF(text=bpf_text,
         cflags=["-include",
                 "/usr/src/zfs-" + KVER + "/zfs_config.h",
+                "-include",
+                "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
                 "-I/usr/src/zfs-" + KVER + "/include/",
-                "-I/usr/src/zfs-" + KVER + "/include/spl",
-                "-I/usr/src/zfs-" + KVER + "/include/",
-                "-I/usr/src/zfs-" + KVER + "/include/linux",
-                "-DCC_USING_FENTRY"])
+                "-I/usr/src/zfs-" + KVER + "/include/spl"])
 
 b.attach_kprobe(event="zfs_write", fn_name="zfs_write_entry")
 b.attach_kretprobe(event="zfs_write", fn_name="zfs_write_return")


### PR DESCRIPTION
The estat zil command fails to load with the unknown type errors as show below.  
```
$ sudo estat zil
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:6:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
In file included from /virtual/main.c:9:
In file included from /usr/src/zfs-5.4.0-48-generic/include/sys/zfs_znode.h:30:
In file included from /usr/src/zfs-5.4.0-48-generic/include/sys/zfs_acl.h:35:
/usr/src/zfs-5.4.0-48-generic/include/sys/zfs_fuid.h:101:30: error: unknown type name 'zfsvfs_t'
```

There is also a warning about CC_USING_FENTRY that can be cleaned up.  The zil script is a standalone and sets up it's own bpf include path.   This change brings it in line with what estat uses for built in scripts and what the built in scripts like zpl include to access zfsvfs_t type. 

I tested that the script loaded on esx and aws vms: 

Running on esx(Linux 5.4.0-48-generic x86_64):
$ sudo ./estat.py zil
 Tracing enabled... Hit Ctrl-C to end.
....

Running on aws(Linux 5.4.0-1025-aws x86_64)
$ sudo ./estat.py zil
 Tracing enabled... Hit Ctrl-C to end.
...


