### PR TITLE
Sync 6.0 Stage with master

### DIFF
--- a/bpf/estat/backend-io.c
+++ b/bpf/estat/backend-io.c
@@ -15,9 +15,8 @@
 #define	READ_STR "read "
 #define	WRITE_STR "write "
 #define	OP_NAME_LEN 7
-#define	DEV_NAME_LEN 8
 #define	NAME_LENGTH (OP_NAME_LEN + 1)
-#define	AXIS_LENGTH (DEV_NAME_LEN + 1)
+#define	AXIS_LENGTH (DISK_NAME_LEN + 1)
 
 // Structure to hold thread local data
 typedef struct {
@@ -25,7 +24,7 @@ typedef struct {
 	unsigned int size;
 	unsigned int cmd_flags;
 	u32 err;
-	char device[DEV_NAME_LEN];
+	char device[DISK_NAME_LEN];
 } io_data_t;
 
 BPF_HASH(io_base_data, u64, io_data_t);
@@ -40,7 +39,7 @@ disk_io_start(struct pt_regs *ctx, struct request *reqp)
 	data.ts = bpf_ktime_get_ns();
 	data.cmd_flags = reqp->cmd_flags;
 	data.size = reqp->__data_len;
-	__builtin_memcpy(&data.device, diskp->disk_name, DEV_NAME_LEN);
+	bpf_probe_read_str(&data.device, DISK_NAME_LEN, diskp->disk_name);
 	io_base_data.update((u64 *) &reqp, &data);
 	return (0);
 }

--- a/bpf/estat/zpl.c
+++ b/bpf/estat/zpl.c
@@ -57,7 +57,7 @@ zfs_read_write_entry(io_info_t *info, struct inode *ip, uio_t *uio, int flags)
 	info->start_time = bpf_ktime_get_ns();
 	info->bytes = uio->uio_resid;
 	info->is_sync =
-	    z_os->os_sync == ZFS_SYNC_ALWAYS || (flags & (FSYNC | FDSYNC));
+	    z_os->os_sync == ZFS_SYNC_ALWAYS || (flags & (O_SYNC | O_DSYNC));
 
 	u32 tid = bpf_get_current_pid_tgid();
 	io_info_t *infop = io_info_map.lookup(&tid);

--- a/bpf/standalone/arc_prefetch.py
+++ b/bpf/standalone/arc_prefetch.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020, 2016 by Delphix. All rights reserved.
+#
+
+#
+# This script provides read latency data for prefetch I/O.
+#
+# usage: arc-prefetch.d <zpool-name>
+#
+
+from bcc import BPF
+from time import sleep
+from time import strftime
+import argparse
+import os
+import sys
+
+#
+# Find BCCHelper. If we are being run from the repo, we should be able to find
+# it in the repo's lib/ directory. If we can't find that, look for BCCHelper
+# in its install location.
+#
+base_dir = os.path.dirname(__file__) + "/../../"
+if not os.path.exists(base_dir + "lib/bcchelper.py"):
+    base_dir = "/usr/share/performance-diagnostics/"
+sys.path.append(base_dir + 'lib/')
+# flake8 wants these at the top of the file, but path update must come first
+from bcchelper import BCCHelper            # noqa: E402
+from bcchelper import BCCMapIndex          # noqa: E402
+from bcchelper import BCCPerCPUIntArray    # noqa: E402
+from bcchelper import BCCPoolCompare       # noqa: E402
+
+
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
+#include <uapi/linux/ptrace.h>
+#include <linux/bpf_common.h>
+#include <uapi/linux/bpf.h>
+
+#include <sys/uio.h>
+#include <sys/condvar.h>
+#include <sys/xvattr.h>
+#include <sys/zfs_rlock.h>
+#include <sys/zfs_znode.h>
+#include <sys/dmu_objset.h>
+#include <sys/spa_impl.h>
+#include <sys/arc_impl.h>
+"""
+parser = argparse.ArgumentParser(
+        description='Collect arc_prefetch statistics.',
+        usage='estat arc-prefetch [options]')
+parser.add_argument('-p', '--pool', type=str, action='store',
+                    dest='pool',
+                    help='The pool to monitor (default: domain0)')
+args = parser.parse_args()
+
+# Add pool POOL_COMPARE macro to the bpf_text C code
+if (args.pool):
+    pool = args.pool
+else:
+    pool = "domain0"
+pool_compare = BCCPoolCompare(pool)
+if not pool_compare.get_pool_pointer():
+    print("Warning: No pool filtering, unable to find zfs pool " + pool)
+bpf_text += pool_compare.get_pool_compare_code()
+
+bpf_text += """
+#define ARC_FLAG_PREFETCH    (1 << 2)        /* I/O is a prefetch */
+
+typedef struct {
+    u64 zfs_read_ts;
+    u64 arc_read_ts;
+    zio_t *zio;
+}arc_prefetch_info_t;
+
+typedef struct {
+    u64 t;
+    u32 index;
+    u64 cpuid;
+} lat_key;
+
+HIST_KEY(hist_lat_key, lat_key);
+
+BPF_HASH(arc_prefetch_info, u32, arc_prefetch_info_t);
+BPF_HASH(zio_read_exit_time, zio_t *, u64);
+
+BPF_HASH(read_latency, hist_lat_key, u64);
+BPF_HASH(read_average, lat_key, average_t);
+BPF_PERCPU_ARRAY(arc_count, u32, NCOUNT_INDEX);
+
+int zfs_read_entry(struct pt_regs *ctx, struct inode *ip)
+{
+    u32 tid = bpf_get_current_pid_tgid();
+    u64 ts = bpf_ktime_get_ns();
+    arc_prefetch_info_t info = {ts};
+
+    // filter by pool
+    zfsvfs_t *zfsvfs = ip->i_sb->s_fs_info;
+    objset_t *z_os = zfsvfs->z_os;
+    spa_t *spa = z_os->os_spa;
+    if (POOL_COMPARE(spa))
+        arc_prefetch_info.update(&tid, &info);
+
+    return 0;
+}
+
+int zfs_read_return(struct pt_regs *ctx)
+{
+    u32 tid = bpf_get_current_pid_tgid();
+    arc_prefetch_info_t *info = arc_prefetch_info.lookup(&tid);
+
+    if (info == NULL)
+        return 0;
+
+    if (info != NULL)
+        arc_prefetch_info.delete(&tid);
+    return 0;
+}
+
+
+int arc_hit_entry(struct pt_regs *ctx)
+{
+    u32 tid = bpf_get_current_pid_tgid();
+    arc_prefetch_info_t *info = arc_prefetch_info.lookup(&tid);
+    if (info == NULL || info->zfs_read_ts == 0)
+        return 0;
+
+    arc_count.increment(ARC_HIT_COUNT);
+    return 0;
+}
+
+int arc_miss_entry(struct pt_regs *ctx)
+{
+    u32 tid = bpf_get_current_pid_tgid();
+    arc_prefetch_info_t *info = arc_prefetch_info.lookup(&tid);
+    if (info == NULL || info->zfs_read_ts == 0)
+        return 0;
+
+    arc_count.increment(ARC_MISS_COUNT);
+    return 0;
+}
+
+int arc_read_entry(struct pt_regs *ctx)
+{
+    u32 tid = bpf_get_current_pid_tgid();
+    arc_prefetch_info_t *info = arc_prefetch_info.lookup(&tid);
+    if (info == NULL || info->zfs_read_ts == 0)
+        return 0;
+
+    info->arc_read_ts = bpf_ktime_get_ns();
+    return 0;
+}
+
+int arc_read_return(struct pt_regs *ctx)
+{
+    u32 tid = bpf_get_current_pid_tgid();
+    arc_prefetch_info_t *info = arc_prefetch_info.lookup(&tid);
+    if (info == NULL || info->arc_read_ts == 0)
+        return 0;
+
+    u64 elapsed = (bpf_ktime_get_ns() - info->arc_read_ts) / 1000;
+    lat_key lkey = {1, ARC_ISSUE_LATENCY, 0};
+    lkey.cpuid = bpf_get_smp_processor_id();
+    u32 slot = bpf_log2l(elapsed);
+    HIST_KEY_INITIALIZE(hist_lat_key, hkey, lkey, slot);
+    read_latency.increment(hkey);
+
+    average_t *average = read_average.lookup(&lkey);
+    if (average == NULL) {
+         average_t initial_average = {1, elapsed};
+         read_average.update(&lkey, &initial_average);
+         return 0;
+    }
+    average->count += 1;
+    average->sum += elapsed;
+    return 0;
+}
+
+int zio_read_entry(struct pt_regs *ctx, zio_t *zio)
+{
+    u32 tid = bpf_get_current_pid_tgid();
+    arc_prefetch_info_t *info = arc_prefetch_info.lookup(&tid);
+    if (info == NULL || info->arc_read_ts == 0)
+        return 0;
+
+    info->zio = zio;
+    return 0;
+}
+
+int zio_read_return(struct pt_regs *ctx)
+{
+    u32 tid = bpf_get_current_pid_tgid();
+    u64 zio_exit_ts = bpf_ktime_get_ns();
+    arc_prefetch_info_t *info = arc_prefetch_info.lookup(&tid);
+    if (info == NULL || info->zio == NULL)
+        return 0;
+
+    zio_read_exit_time.update(&info->zio, &zio_exit_ts);
+    return 0;
+}
+
+int arc_read_done_entry(struct pt_regs *ctx, zio_t *zio)
+{
+    arc_buf_hdr_t *hdr = (arc_buf_hdr_t *) zio->io_private;
+    u64 zero = 0;
+
+    u64 *zio_exit_ts = zio_read_exit_time.lookup(&zio);
+    if (zio_exit_ts == NULL || *zio_exit_ts == 0) {
+            return 0;
+    }
+
+    u64 zio_ts = *zio_exit_ts;
+    u64 elapsed = (bpf_ktime_get_ns() - zio_ts) / 1000;
+
+    hist_lat_key hkey = { };
+    lat_key *lkey = HIST_KEY_GET_AGGKEY(&hkey);
+    u32 count_index;
+    if (hdr->b_flags & ARC_FLAG_PREFETCH) {
+        count_index = ARC_PREFETCH_ZIO_COUNT;
+        lkey->index = ARC_PREFETCH_ZIO_LATENCY;
+    } else {   // normal zio
+        count_index = ARC_NORMAL_ZIO_COUNT;
+        lkey->index = ARC_NORMAL_ZIO_LATENCY;
+    }
+    lkey->t = 1;
+    lkey->cpuid = bpf_get_smp_processor_id();
+
+    HIST_KEY_SET_SLOT(&hkey, bpf_log2(elapsed));
+    arc_count.increment(count_index);
+    read_latency.increment(hkey);
+    zio_read_exit_time.update(&zio, &zero);
+    average_t *average = read_average.lookup(lkey);
+    if (average == NULL) {
+         average_t initial_average = {1, elapsed};
+         read_average.update(lkey, &initial_average);
+         return 0;
+    }
+    average->count += 1;
+    average->sum += elapsed;
+
+    return 0;
+ }
+
+"""
+
+
+class ArcCountIndex(BCCMapIndex):
+    ARC_HIT_COUNT = (0, 'ARC_HIT_COUNT', 'prefetch hit count')
+    ARC_MISS_COUNT = (1, 'ARC_MISS_COUNT', 'prefetch miss count')
+    ARC_NORMAL_ZIO_COUNT = (2, 'ARC_NORMAL_ZIO_COUNT', 'normal read count')
+    ARC_PREFETCH_ZIO_COUNT = (3, 'ARC_PREFETCH_ZIO_COUNT',
+                              'prefetch read count')
+
+
+class ArcLatencyIndex(BCCMapIndex):
+    ARC_ISSUE_LATENCY = (0, 'ARC_ISSUE_LATENCY', 'arc read latency')
+    ARC_NORMAL_ZIO_AVERAGE = (1, 'ARC_NORMAL_ZIO_LATENCY',
+                              'normal read latency')
+    ARC_PREFETCH_ZIO_AVERAGE = (2, 'ARC_PREFETCH_ZIO_LATENCY',
+                                'prefetch read latency')
+
+
+KVER = os.popen('uname -r').read().rstrip()
+
+flags = ["-include",
+         "/usr/src/zfs-" + KVER + "/zfs_config.h",
+         "-include",
+         "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
+         "-I/usr/src/zfs-" + KVER + "/include/",
+         "-I/usr/src/zfs-" + KVER + "/include/spl/",
+         "-I/usr/src/zfs-" + KVER + "/include/linux",
+         "-DCC_USING_FENTRY",
+         "-DNCOUNT_INDEX=" + str(len(ArcCountIndex)),
+         "-DNAVERAGE_INDEX=" + str(len(ArcLatencyIndex))] \
+         + ArcCountIndex.getCDefinitions() \
+         + ArcLatencyIndex.getCDefinitions()
+
+b = BPF(text=bpf_text, cflags=flags)
+
+b.attach_kprobe(event="zfs_read", fn_name="zfs_read_entry")
+b.attach_kretprobe(event="zfs_read", fn_name="zfs_read_return")
+b.attach_kprobe(event="trace_zfs_arc__hit", fn_name="arc_hit_entry")
+b.attach_kprobe(event="trace_zfs_arc__miss", fn_name="arc_miss_entry")
+b.attach_kprobe(event="arc_read", fn_name="arc_read_entry")
+b.attach_kretprobe(event="arc_read", fn_name="arc_read_return")
+b.attach_kprobe(event="zio_read", fn_name="zio_read_entry")
+b.attach_kretprobe(event="zio_read", fn_name="zio_read_return")
+b.attach_kprobe(event="arc_read_done", fn_name="arc_read_done_entry")
+
+read_latency_helper = BCCHelper(b, BCCHelper.ESTAT_PRINT_MODE)
+read_latency_helper.add_aggregation("read_latency",
+                                    BCCHelper.LOG_HISTOGRAM_AGGREGATION,
+                                    "microseconds")
+read_latency_helper.add_aggregation("read_average",
+                                    BCCHelper.AVERAGE_AGGREGATION,
+                                    "avg latency(us)")
+read_latency_helper.add_key_type("index", BCCHelper.MAP_INDEX_TYPE,
+                                 ArcLatencyIndex)
+call_count_helper = BCCPerCPUIntArray(b, "arc_count", ArcCountIndex)
+
+
+while True:
+    try:
+        sleep(5)
+    except KeyboardInterrupt:
+        print("%-16s\n" % strftime("%D - %H:%M:%S %Z"))
+        call_count_helper.printall()
+        read_latency_helper.printall()
+        break
+    try:
+        print("%-16s\n" % strftime("%D - %H:%M:%S %Z"))
+        call_count_helper.printall()
+        read_latency_helper.printall()
+    except Exception as e:
+        print(str(e))
+        break

--- a/bpf/standalone/zil.py
+++ b/bpf/standalone/zil.py
@@ -25,16 +25,15 @@ from time import sleep, strftime
 import argparse
 import sys
 import os
-repo_lib_dir = os.path.dirname(__file__) + "/../../lib/"
-if os.path.exists(repo_lib_dir + "bcchelper.py"):
-    sys.path.append(repo_lib_dir)
-else:
-    sys.path.append("/usr/share/performance-diagnostics/lib/")
-from bcchelper import BCCHelper  # noqa 
+base_dir = os.path.dirname(__file__) + "/../../"
+if not os.path.exists(base_dir + "lib/bcchelper.py"):
+    base_dir = "/usr/share/performance-diagnostics/"
+sys.path.append(base_dir + 'lib/')
+from bcchelper import BCCHelper   # noqa: E402
 
 # define BPF program
-bpf_text = """
-#include "/opt/delphix/server/etc/bcc_helper.h"
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
@@ -132,7 +131,7 @@ uio_t *uio, int ioflag)
                 return 0;
 
     info.alloc_count = 0;
-    info.sync = ioflag & (FSYNC | FDSYNC) ||
+    info.sync = ioflag & (O_SYNC | O_DSYNC) ||
             zfsvfs->z_os->os_sync == ZFS_SYNC_ALWAYS;
     zil_info_map.update(&tid, &info);
     return 0;

--- a/bpf/standalone/zil.py
+++ b/bpf/standalone/zil.py
@@ -37,9 +37,7 @@ bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
-#include <sys/file.h>
-#include <sys/fs/zfs.h>
-#include <sys/zfs_vfsops.h>
+#include <sys/xvattr.h>
 #include <sys/zfs_znode.h>
 #include <sys/dmu_objset.h>
 #include <sys/spa_impl.h>
@@ -256,11 +254,10 @@ KVER = os.popen('uname -r').read().rstrip()
 b = BPF(text=bpf_text,
         cflags=["-include",
                 "/usr/src/zfs-" + KVER + "/zfs_config.h",
+                "-include",
+                "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
                 "-I/usr/src/zfs-" + KVER + "/include/",
-                "-I/usr/src/zfs-" + KVER + "/include/spl",
-                "-I/usr/src/zfs-" + KVER + "/include/",
-                "-I/usr/src/zfs-" + KVER + "/include/linux",
-                "-DCC_USING_FENTRY"])
+                "-I/usr/src/zfs-" + KVER + "/include/spl"])
 
 b.attach_kprobe(event="zfs_write", fn_name="zfs_write_entry")
 b.attach_kretprobe(event="zfs_write", fn_name="zfs_write_return")

--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -22,14 +22,13 @@ from bcchelper import BCCHelper   # noqa: E402
 
 
 # BPF disk io program
-bpf_text = """
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <linux/blkdev.h>
 #include <linux/blk_types.h>
 #include <uapi/linux/bpf.h>
-#include "/opt/delphix/server/etc/bcc_helper.h"
-
 
 // Definitions for this script
 #define READ_STR "read"

--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -69,7 +69,7 @@ int disk_io_start(struct pt_regs *ctx, struct request *reqp)
     data.ts = bpf_ktime_get_ns();
     data.cmd_flags = reqp->cmd_flags;
     data.size = reqp->__data_len;
-    __builtin_memcpy(&data.device, diskp->disk_name, DISK_NAME_LEN);
+    bpf_probe_read_str(&data.device, DISK_NAME_LEN, diskp->disk_name);
     io_base_data.update((u64 *) &reqp, &data);
     return 0;
 }

--- a/bpf/stbtrace/iscsi.st
+++ b/bpf/stbtrace/iscsi.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -21,11 +21,11 @@ sys.path.append(base_dir + 'lib/')
 from bcchelper import BCCHelper   # noqa: E402
 
 # BPF txg program
-bpf_text = """
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
-#include "/opt/delphix/server/etc/bcc_helper.h"
 
 #include "target/iscsi/iscsi_target_core.h"
 

--- a/bpf/stbtrace/nfs.st
+++ b/bpf/stbtrace/nfs.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -21,12 +21,12 @@ sys.path.append(base_dir + 'lib/')
 from bcchelper import BCCHelper   # noqa: E402
 
 # BPF txg program
-bpf_text = """
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
 #include <linux/sunrpc/svc.h>
-#include "/opt/delphix/server/etc/bcc_helper.h"
 
 
 // nfsd4 definitions from fs/nfsd/xdr4.h

--- a/bpf/stbtrace/vfs.st
+++ b/bpf/stbtrace/vfs.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -21,11 +21,11 @@ sys.path.append(base_dir + 'lib/')
 from bcchelper import BCCHelper   # noqa: E402
 
 # BPF txg program
-bpf_text = """
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
-#include "/opt/delphix/server/etc/bcc_helper.h"
 
 // Definitions for this script
 #define READ_STR "read"

--- a/bpf/stbtrace/zio.st
+++ b/bpf/stbtrace/zio.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -21,11 +21,11 @@ sys.path.append(base_dir + 'lib/')
 from bcchelper import BCCHelper   # noqa: E402
 
 # BPF txg program
-bpf_text = """
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
-#include "/opt/delphix/server/etc/bcc_helper.h"
 #include <sys/zio.h>
 #include <sys/fs/zfs.h>
 

--- a/bpf/stbtrace/zpl.st
+++ b/bpf/stbtrace/zpl.st
@@ -173,7 +173,12 @@ int zfs_write_done(struct pt_regs *ctx)
 
 KVER = os.popen('uname -r').read().rstrip()
 b = BPF(text=bpf_text,
-        cflags=["-I/usr/src/zfs-" + KVER + "/include/spl/",
+        cflags=["-include",
+                "/usr/src/zfs-" + KVER + "/zfs_config.h",
+                "-include",
+                "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
+                "-I/usr/src/zfs-" + KVER + "/include/",
+                "-I/usr/src/zfs-" + KVER + "/include/spl/",
                 "-DCC_USING_FENTRY"])
 
 b.attach_kprobe(event="zfs_read", fn_name="zfs_read_start")

--- a/bpf/stbtrace/zpl.st
+++ b/bpf/stbtrace/zpl.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -22,11 +22,11 @@ from bcchelper import BCCHelper   # noqa: E402
 
 
 # BPF txg program
-bpf_text = """
+bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
+bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
-#include "/opt/delphix/server/etc/bcc_helper.h"
 
 #include <sys/uio.h>
 

--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -391,6 +391,8 @@ if dump_bpf:
 KVER = os.popen('uname -r').read().rstrip()
 cflags = ["-include",
           "/usr/src/zfs-" + KVER + "/zfs_config.h",
+          "-include",
+          "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
           "-I/usr/src/zfs-" + KVER + "/include/",
           "-I/usr/src/zfs-" + KVER + "/include/spl",
           "-DCC_USING_FENTRY"]

--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -202,7 +202,10 @@ for opt, arg in opts:
         else:
             assert False, "unhandled option: " + opt
 
-if len(rem_args) != 1:
+if len(rem_args) == 0:
+    die("Missing duration argument")
+
+if len(rem_args) > 1:
     die("Too many arguments")
 
 try:

--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -88,7 +88,6 @@ help_msg += """
       -z/-Z     enable/disable size histograms (default: off)
       -q/-Q     enable/disable latency histograms by size (default: off)
       -y/-Y     enable/disable the summary output (default: on)
-      -n/-N     enable/disable normalizing summary by time (default: on)
       -t/-T     enable/disable emitting the summary total (default: on)
       -d LEVEL  set BCC debug level
       -e        emit the resulting eBPF script without executing it
@@ -155,7 +154,6 @@ setattr(args, "lat_hist", False)
 setattr(args, "size_hist", False)
 setattr(args, "latsize_hist", False)
 setattr(args, "summary", True)
-setattr(args, "normalize", True)
 setattr(args, "total", True)
 
 #
@@ -193,7 +191,6 @@ for opt, arg in opts:
                     '-z': "size_hist",
                     '-q': "latsize_hist",
                     '-y': "summary",
-                    '-n': "normalize",
                     '-t': "total"}
         if opt in switches:
             setattr(args, switches[opt], True)
@@ -495,9 +492,10 @@ if monitor:
             ds__delta = ds__end - ds__start
             if not accum:
                 ds__start = ds__end
-            if args.summary and args.normalize:
-                helper1.normalize("ops", ds__delta // 1000000000)
-                helper3.normalize("opst", ds__delta // 1000000000)
+            helper1.normalize("ops", ds__delta // 1000000000)
+            helper1.normalize("data", ds__delta // 1000000000)
+            helper3.normalize("opst", ds__delta // 1000000000)
+            helper3.normalize("datat", ds__delta // 1000000000)
             clear_data = not accum
             if args.latsize_hist:
                 helper2.printall(clear_data)
@@ -516,9 +514,10 @@ else:
         pass
     try:
         ds__delta = int(os.popen("date +%s%N").readlines()[0]) - ds__start
-        if args.summary and args.normalize:
-            helper1.normalize("ops", ds__delta // 1000000000)
-            helper3.normalize("opst", ds__delta // 1000000000)
+        helper1.normalize("ops", ds__delta // 1000000000)
+        helper1.normalize("data", ds__delta // 1000000000)
+        helper3.normalize("opst", ds__delta // 1000000000)
+        helper3.normalize("datat", ds__delta // 1000000000)
         if args.latsize_hist:
             helper2.printall()
         if args.lat_hist or args.size_hist or args.summary:

--- a/lib/bcc_helper.h
+++ b/lib/bcc_helper.h
@@ -26,6 +26,14 @@ typedef struct { \
 	u64		slot; \
 } hist_key_type;
 
+#define HIST_KEY_INITIALIZE(hist_key_type, hist_key, agg_key, slot) \
+        hist_key_type hist_key = {agg_key, slot};
+#define HIST_KEY_GET_AGGKEY(hist_key_ptr) (&(hist_key_ptr)->agg_key)
+#define HIST_KEY_GET_SLOT(hist_key_ptr) ((hist_key_ptr)->slot)
+#define HIST_KEY_SET_SLOT(hist_key_ptr, nslot) (hist_key_ptr)->slot = nslot;
+#define HIST_KEY_SET_AGGKEY(hist_key_ptr, agg_key) (hist_key_ptr)->agg_key = agg_key;
+
+
 /*
  * This function returns the slot, or histogram bucket, for a value based
  * on log linear distribution equivalent to dtrace llquantize(*, 10, 4, 10, 10).

--- a/lib/bcchelper.py
+++ b/lib/bcchelper.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, 2019 Delphix. All rights reserved.
+# Copyright 2018, 2020 Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -16,7 +16,7 @@ Guide.
 https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#1-bpf
 
 Defitions for C helper routines and macros are in
-/opt/delphix/server/etc/bcc_helper.h
+lib/bcc_helper.h
 
 BCC Helper focuses are printing out data from a set of tracing aggregations.
 There are three supported scalar types of aggregations(count, sum, and


### PR DESCRIPTION
This PR backports several commits from master and should effectively sync up master.  

We need to coordinate with an update of bcc to work around the same issue we hit here updating master: 
[#36 Invalid mem errors when using latest BCC](https://github.com/delphix/performance-diagnostics/pull/36)

I tested this on a 6.0/stage machine with an updated bcc that Pavel set up by running all the estat and stbtrace scripts.  While not testing functionality of the scripts, this does make sure the tracing scripts compile and run. It is not clean as these known issues are present: 
[On 6.0.5, estat zpl and zvol subcommands are failing to compile](https://jira.delphix.com/browse/DLPX-72405)
[estat warning messages](https://jira.delphix.com/browse/DLPX-72556)   


sudo ./estat.py backend-io 1
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
1 warning generated.
WARNING: kprobe: blk_start_request - not found
10/31/20 - 16:02:22 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                                   write 
value range                 count ------------- Distribution ------------- 
[700, 800)                      2 |@@@@@@@@@                               
[800, 900)                      3 |@@@@@@@@@@@@@@@@@                       

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
write                                         5              787             1758               68


                                       iops(/s)  throughput(k/s)
total                                         5               68


sudo ./estat.py iscsi 1
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
1 warning generated.
10/31/20 - 16:02:25 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py metaslab-alloc 1
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
1 warning generated.
10/31/20 - 16:02:30 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py nfs 1
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
1 warning generated.
10/31/20 - 16:02:37 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py nfs-by-client 1
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
1 warning generated.
10/31/20 - 16:02:44 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py zio 1
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
1 warning generated.
10/31/20 - 16:02:48 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py zio-queue 1
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
1 warning generated.
10/31/20 - 16:02:52 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py zpl 1
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
/virtual/main.c:92:2: error: unknown type name 'rangelock_t'
        rangelock_t             zv_rangelock;   /* for range locking */
        ^
/virtual/main.c:193:3: warning: 'memcpy' will always overflow; destination buffer has size 5, but size argument is 6 [-Wfortify-source]
                __builtin_memcpy(&axis, "sync", WRITE_LENGTH);
                ^
/virtual/main.c:196:3: warning: 'memcpy' will always overflow; destination buffer has size 5, but size argument is 6 [-Wfortify-source]
                __builtin_memcpy(&axis, "async", WRITE_LENGTH);
                ^
3 warnings and 1 error generated.
Traceback (most recent call last):
  File "./estat.py", line 402, in <module>
    b = BPF(text=bpf_text, cflags=cflags, debug=debug_level)
  File "/usr/lib/python3/dist-packages/bcc/__init__.py", line 364, in __init__
    raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
Exception: Failed to compile BPF module <text>
sudo ./estat.py zil
 Tracing enabled... Hit Ctrl-C to end.
^C10/31/20 - 16:03:11 UTC

sudo ./estat.py txg
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
1 warning generated.
^Csudo ./estat.py arc_prefetch
Warning: No pool filtering, unable to find zfs pool domain0
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
1 warning generated.
10/31/20 - 16:03:32 UTC

prefetch hit count   : 2
10/31/20 - 16:03:37 UTC

prefetch hit count   : 99
^C10/31/20 - 16:03:39 UTC

sudo ./stbtrace.py io
{"t":"1604160222", "op":"write", "device":"nvme0n1", "error":"0", "count":"4", "avgLatency":"813528", "throughput":"49152", "latency":"{800000,2},{900000,1},{1000000,1}", "size":"{16383,4}"}

{"t":"1604160223", "op":"write", "device":"nvme0n1", "error":"0", "count":"5", "avgLatency":"840022", "throughput":"61440", "latency":"{800000,3},{900000,1},{2000000,1}", "size":"{8191,1},{16383,3},{32767,1}"}

^Csudo ./stbtrace.py iscsi
^Csudo ./stbtrace.py nfs
^Csudo ./stbtrace.py vfs
{"t":"1604160235", "op":"write", "sync":"0", "cached":"-1", "count":"126", "avgLatency":"15789", "throughput":"22007", "latency":"{10000,53},{20000,62},{30000,2},{40000,1},{50000,4},{90000,2},{200000,1},{300000,1}", "size":"{63,29},{127,3},{255,63},{511,31}"}

{"t":"1604160235", "op":"read", "sync":"-1", "cached":"1", "count":"130", "avgLatency":"2206", "throughput":"93580", "latency":"{10000,130}", "size":"{31,5},{127,5},{511,15},{1023,105}"}

{"t":"1604160236", "op":"write", "sync":"0", "cached":"-1", "count":"4", "avgLatency":"44290", "throughput":"32768", "latency":"{40000,1},{50000,3}", "size":"{16383,4}"}

{"t":"1604160237", "op":"write", "sync":"0", "cached":"-1", "count":"4", "avgLatency":"41870", "throughput":"32768", "latency":"{30000,1},{50000,3}", "size":"{16383,4}"}

^Csudo ./stbtrace.py zio
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
1 warning generated.
{"t":"1604160241", "op":"write", "count":"1", "avgLatency":"1112882", "throughput":"20480", "latency":"{2000000,1}", "size":"{32767,1}"}

{"t":"1604160242", "op":"write", "count":"7", "avgLatency":"924654", "throughput":"110592", "latency":"{800000,1},{900000,3},{1000000,2},{2000000,1}", "size":"{16383,5},{32767,2}"}

{"t":"1604160243", "op":"write", "count":"145", "avgLatency":"965054", "throughput":"1545216", "latency":"{700000,15},{800000,25},{900000,40},{1000000,18},{2000000,46},{3000000,1}", "size":"{1023,10},{2047,23},{4095,24},{8191,39},{16383,24},{32767,14},{65535,8},{131071,3}"}

^Csudo ./stbtrace.py zpl
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
1 warning generated.
{"t":"1604160246", "op":"write", "sync":"0", "cached":"-1", "count":"4", "avgLatency":"49799", "throughput":"32768", "latency":"{50000,1},{60000,3}", "size":"{16383,4}"}

{"t":"1604160247", "op":"write", "sync":"0", "cached":"-1", "count":"16", "avgLatency":"35498", "throughput":"103034", "latency":"{20000,4},{30000,3},{40000,1},{50000,6},{60000,1},{70000,1}", "size":"{1023,2},{4095,2},{8191,1},{16383,11}"}

{"t":"1604160247", "op":"read", "sync":"-1", "cached":"1", "count":"33", "avgLatency":"5056", "throughput":"197120", "latency":"{10000,29},{20000,3},{30000,1}", "size":"{1023,3},{2047,6},{4095,1},{8191,1},{16383,22}"}

{"t":"1604160247", "op":"write", "sync":"0", "cached":"-1", "count":"3", "avgLatency":"63960", "throughput":"24576", "latency":"{60000,1},{70000,1},{80000,1}", "size":"{16383,3}"}

{"t":"1604160248", "op":"write", "sync":"0", "cached":"-1", "count":"11", "avgLatency":"95251", "throughput":"106496", "latency":"{40000,2},{50000,3},{60000,2},{70000,2},{90000,1},{600000,1}", "size":"{16383,10},{32767,1}"}

{"t":"1604160248", "op":"write", "sync":"0", "cached":"-1", "count":"3", "avgLatency":"49222", "throughput":"24576", "latency":"{50000,2},{60000,1}", "size":"{16383,3}"}

{"t":"1604160249", "op":"write", "sync":"0", "cached":"-1", "count":"11", "avgLatency":"45978", "throughput":"90112", "latency":"{30000,1},{40000,1},{50000,6},{60000,3}", "size":"{16383,11}"}

./nfs_threads.py
   packets   sockets   threads   threads  metadata      read      read     write     write
   arrived  enqueued     woken      used     calls      iops   thruput      iops   thruput
         0         0         0         0         0       0.0       0KB       0.0       0KB
