### PR TITLE
DLPX-72556 estat warning messages

### DIFF
--- a/bpf/standalone/arc_prefetch.py
+++ b/bpf/standalone/arc_prefetch.py
@@ -270,7 +270,6 @@ flags = ["-include",
          "-I/usr/src/zfs-" + KVER + "/include/",
          "-I/usr/src/zfs-" + KVER + "/include/spl/",
          "-I/usr/src/zfs-" + KVER + "/include/linux",
-         "-DCC_USING_FENTRY",
          "-DNCOUNT_INDEX=" + str(len(ArcCountIndex)),
          "-DNAVERAGE_INDEX=" + str(len(ArcLatencyIndex))] \
          + ArcCountIndex.getCDefinitions() \

--- a/bpf/standalone/txg.py
+++ b/bpf/standalone/txg.py
@@ -349,8 +349,7 @@ b = BPF(text=bpf_text,
                 "-I/usr/src/zfs-" + KVER + "/include/",
                 "-I/usr/src/zfs-" + KVER + "/include/spl",
                 "-I/usr/src/zfs-" + KVER + "/include/",
-                "-I/usr/src/zfs-" + KVER + "/include/linux",
-                "-DCC_USING_FENTRY"])
+                "-I/usr/src/zfs-" + KVER + "/include/linux"])
 
 b.attach_kprobe(event="spa_sync", fn_name="spa_sync_entry")
 b.attach_kretprobe(event="spa_sync", fn_name="spa_sync_return")

--- a/bpf/stbtrace/zio.st
+++ b/bpf/stbtrace/zio.st
@@ -130,8 +130,7 @@ b = BPF(text=bpf_text, cflags=["-include",
                                "/usr/src/zfs-" + KVER + "/zfs_config.h",
                                "-I/usr/src/zfs-" + KVER + "/include/",
                                "-I/usr/src/zfs-" + KVER + "/include/spl/",
-                               "-I/usr/src/zfs-" + KVER + "/include/linux",
-                               "-DCC_USING_FENTRY"])
+                               "-I/usr/src/zfs-" + KVER + "/include/linux"])
 
 b.attach_kretprobe(event="vdev_queue_io_to_issue",
                    fn_name="vdev_queue_issue_return")

--- a/bpf/stbtrace/zpl.st
+++ b/bpf/stbtrace/zpl.st
@@ -178,8 +178,7 @@ b = BPF(text=bpf_text,
                 "-include",
                 "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
                 "-I/usr/src/zfs-" + KVER + "/include/",
-                "-I/usr/src/zfs-" + KVER + "/include/spl/",
-                "-DCC_USING_FENTRY"])
+                "-I/usr/src/zfs-" + KVER + "/include/spl/"])
 
 b.attach_kprobe(event="zfs_read", fn_name="zfs_read_start")
 b.attach_kprobe(event="zfs_write", fn_name="zfs_write_start")

--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -395,8 +395,7 @@ cflags = ["-include",
           "-include",
           "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
           "-I/usr/src/zfs-" + KVER + "/include/",
-          "-I/usr/src/zfs-" + KVER + "/include/spl",
-          "-DCC_USING_FENTRY"]
+          "-I/usr/src/zfs-" + KVER + "/include/spl"]
 if script_arg:
     cflags.append("-DOPTARG=\"" + script_arg + "\"")
 


### PR DESCRIPTION
This PR addresses warning messages like the following: 
```
In file included from <built-in>:3:
/virtual/include/bcc/helpers.h:47:9: warning: 'CC_USING_FENTRY' macro redefined [-Wmacro-redefined]
#define CC_USING_FENTRY
        ^
<command line>:7:9: note: previous definition is here
#define CC_USING_FENTRY 1
        ^
1 warning generated.
```

I executed all the scripts and do not see any warning messages or any new compilation issues.  

sudo ./estat.py backend-io 1
WARNING: kprobe: blk_start_request - not found
10/31/20 - 16:45:35 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                                   write 
value range                 count ------------- Distribution ------------- 
[700, 800)                      1 |@                                       
[900, 1000)                     1 |@                                       
[1000, 2000)                    4 |@@@@@@@@@@@@@@@@@@                      
[3000, 4000)                    1 |@                                       

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
write                                         7             1509          1007773              100


                                       iops(/s)  throughput(k/s)
total                                         7              100


sudo ./estat.py iscsi 1
10/31/20 - 16:45:38 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py metaslab-alloc 1
10/31/20 - 16:45:41 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                 /dev/disk/by-id, success
value range                 count ------------- Distribution ------------- 
[0, 10)                       101 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@   
[10, 20)                        8 |@@@                                     
[20, 30)                        1 |@                                       

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
/dev/disk/by-id, success                    110                3               15             1087


                                       iops(/s)  throughput(k/s)
total                                       110             1087


sudo ./estat.py nfs 1
10/31/20 - 16:45:46 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py nfs-by-client 1
10/31/20 - 16:45:52 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py zio 1
10/31/20 - 16:45:55 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                             write, syncw
value range                 count ------------- Distribution ------------- 
[700, 800)                      1 |@                                       
[1000, 2000)                    5 |@@@@@@@@@@@@@@@@@@@@@@@@@@@             

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
write, syncw                                  6             1223            72851               80


                                       iops(/s)  throughput(k/s)
total                                         6               80


sudo ./estat.py zio-queue 1
10/31/20 - 16:45:58 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                             write, syncw
value range                 count ------------- Distribution ------------- 
[0, 10)                         6 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@      

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
write, syncw                                  6                4                1               72


                                       iops(/s)  throughput(k/s)
total                                         6               72


sudo ./estat.py zpl 1
In file included from /virtual/main.c:63:
/usr/src/zfs-5.4.0-48-generic/include/sys/zvol_impl.h:52:2: error: unknown type name 'dataset_kstats_t'
        dataset_kstats_t        zv_kstat;       /* zvol kstats */
        ^
1 error generated.
Traceback (most recent call last):
  File "./estat.py", line 402, in <module>
    b = BPF(text=bpf_text, cflags=cflags, debug=debug_level)
  File "/usr/lib/python3/dist-packages/bcc/__init__.py", line 349, in __init__
    raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
Exception: Failed to compile BPF module <text>
sudo ./estat.py zil
 Tracing enabled... Hit Ctrl-C to end.
^C10/31/20 - 16:47:01 UTC

sudo ./estat.py txg
        date                 txg     time since last sync
         |                    |         |   sync time
         |                    |         |        |  (%% pass 1)
         |                    |         |        |    |     highest dirty (%%) 
         |                    |         |        |    |           |  highest throttle delay
         |                    |         |        |    |           |            |      |  avg delay
         v                    v         v        v    v           v            v      v       v
Sat Oct 31 16:47:09 2020      49572     0ms    31ms (94 pass 1)  10MB ( 1)    0us     0ms    0ms
^Csudo ./estat.py arc_prefetch
10/31/20 - 16:47:18 UTC

^C10/31/20 - 16:47:20 UTC

sudo ./stbtrace.py io
{"t":"1604162843", "op":"write", "device":"sdb", "error":"0", "count":"1", "avgLatency":"2581745", "throughput":"12288", "latency":"{3000000,1}", "size":"{16383,1}"}

{"t":"1604162844", "op":"write", "device":"sdb", "error":"0", "count":"1", "avgLatency":"1154328", "throughput":"12288", "latency":"{2000000,1}", "size":"{16383,1}"}

{"t":"1604162844", "op":"write", "device":"sdc", "error":"0", "count":"1", "avgLatency":"1151306", "throughput":"12288", "latency":"{2000000,1}", "size":"{16383,1}"}

{"t":"1604162844", "op":"write", "device":"sdd", "error":"0", "count":"2", "avgLatency":"1182776", "throughput":"32768", "latency":"{2000000,2}", "size":"{16383,1},{32767,1}"}

{"t":"1604162844", "op":"write", "device":"sdb", "error":"0", "count":"1", "avgLatency":"1355694", "throughput":"12288", "latency":"{2000000,1}", "size":"{16383,1}"}

{"t":"1604162844", "op":"write", "device":"sdc", "error":"0", "count":"1", "avgLatency":"813503", "throughput":"12288", "latency":"{900000,1}", "size":"{16383,1}"}

{"t":"1604162845", "op":"read", "device":"", "error":"0", "count":"1", "avgLatency":"136719", "throughput":"8", "latency":"{200000,1}", "size":"{15,1}"}

{"t":"1604162845", "op":"write", "device":"sdb", "error":"0", "count":"1", "avgLatency":"1174231", "throughput":"12288", "latency":"{2000000,1}", "size":"{16383,1}"}

{"t":"1604162845", "op":"write", "device":"sdc", "error":"0", "count":"1", "avgLatency":"1188452", "throughput":"12288", "latency":"{2000000,1}", "size":"{16383,1}"}

{"t":"1604162845", "op":"write", "device":"sdd", "error":"0", "count":"2", "avgLatency":"1083238", "throughput":"24576", "latency":"{1000000,1},{2000000,1}", "size":"{16383,2}"}

{"t":"1604162845", "op":"write", "device":"sdb", "error":"0", "count":"30", "avgLatency":"1160701", "throughput":"183808", "latency":"{600000,2},{700000,2},{800000,5},{900000,4},{1000000,7},{2000000,7},{3000000,1},{4000000,2}", "size":"{1023,5},{2047,9},{4095,3},{8191,5},{16383,4},{32767,3},{65535,1}"}

{"t":"1604162845", "op":"write", "device":"sdc", "error":"0", "count":"31", "avgLatency":"1010402", "throughput":"196096", "latency":"{600000,2},{700000,5},{800000,5},{900000,7},{1000000,4},{2000000,7},{5000000,1}", "size":"{1023,5},{2047,9},{4095,3},{8191,5},{16383,5},{32767,3},{65535,1}"}

{"t":"1604162845", "op":"write", "device":"sdd", "error":"0", "count":"32", "avgLatency":"1155545", "throughput":"145920", "latency":"{700000,3},{800000,8},{900000,8},{1000000,4},{2000000,6},{3000000,1},{4000000,2}", "size":"{1023,6},{2047,11},{4095,3},{8191,6},{16383,3},{32767,3}"}

{"t":"1604162846", "op":"write", "device":"sdb", "error":"0", "count":"2", "avgLatency":"1282255", "throughput":"32768", "latency":"{1000000,1},{2000000,1}", "size":"{16383,1},{32767,1}"}

{"t":"1604162846", "op":"write", "device":"sdc", "error":"0", "count":"1", "avgLatency":"1055364", "throughput":"12288", "latency":"{2000000,1}", "size":"{16383,1}"}

{"t":"1604162846", "op":"write", "device":"sdd", "error":"0", "count":"1", "avgLatency":"987049", "throughput":"12288", "latency":"{1000000,1}", "size":"{16383,1}"}

^Csudo ./stbtrace.py iscsi
^Csudo ./stbtrace.py nfs
^Csudo ./stbtrace.py vfs
^Csudo ./stbtrace.py zio
{"t":"1604162854", "op":"write", "count":"5", "avgLatency":"1074423", "throughput":"61440", "latency":"{900000,1},{1000000,1},{2000000,3}", "size":"{16383,5}"}

{"t":"1604162855", "op":"write", "count":"1", "avgLatency":"1366205", "throughput":"20480", "latency":"{2000000,1}", "size":"{32767,1}"}

{"t":"1604162855", "op":"write", "count":"4", "avgLatency":"1682554", "throughput":"49152", "latency":"{900000,1},{2000000,2},{4000000,1}", "size":"{16383,4}"}

{"t":"1604162856", "op":"write", "count":"118", "avgLatency":"1316471", "throughput":"499200", "latency":"{600000,2},{700000,27},{800000,25},{900000,13},{1000000,5},{2000000,25},{3000000,11},{4000000,4},{5000000,3},{6000000,3}", "size":"{1023,21},{2047,36},{4095,19},{8191,27},{16383,7},{32767,6},{65535,2}"}

^Csudo ./stbtrace.py zpl
{"t":"1604162857", "op":"write", "sync":"0", "cached":"-1", "count":"6", "avgLatency":"34453", "throughput":"57344", "latency":"{30000,2},{40000,2},{50000,2}", "size":"{16383,5},{32767,1}"}

{"t":"1604162858", "op":"write", "sync":"0", "cached":"-1", "count":"8", "avgLatency":"35807", "throughput":"49576", "latency":"{10000,1},{30000,1},{40000,3},{50000,1},{60000,2}", "size":"{127,2},{255,1},{16383,4},{32767,1}"}

