### PR TITLE
Backport of estat updates for 6.0.7.0

### DIFF
--- a/bpf/estat/zvol.c
+++ b/bpf/estat/zvol.c
@@ -11,48 +11,25 @@
 #include <sys/zil_impl.h>
 #include <sys/zfs_rlock.h>
 #include <sys/spa_impl.h>
-#include <sys/zvol.h>
 #include <sys/dataset_kstats.h>
+#include <sys/zvol_impl.h>
+
 
 #define	ZVOL_WCE 0x8
 #define	ZVOL_READ 1
 #define	ZVOL_WRITE 2
 #define	NAME_LENGTH 6
-#define	AXIS_LENGTH 5
+#define	AXIS_LENGTH 6
 #define	READ_LENGTH 5
 #define	WRITE_LENGTH 6
+#define	SYNC_LENGTH 5
+#define	ASYNC_LENGTH 6
 
 #ifndef OPTARG
 #define	POOL "domain0"
 #else
 #define	POOL (OPTARG)
 #endif
-
-/*
- * Copied and duplicated from "module/zfs/zvol.c" of the ZFS repository.
- */
-typedef struct zvol_state {
-	char			zv_name[MAXNAMELEN];	/* name */
-	uint64_t		zv_volsize;		/* advertised space */
-	uint64_t		zv_volblocksize;	/* volume block size */
-	objset_t		*zv_objset;	/* objset handle */
-	uint32_t		zv_flags;	/* ZVOL_* flags */
-	uint32_t		zv_open_count;	/* open counts */
-	uint32_t		zv_changed;	/* disk changed */
-	zilog_t			*zv_zilog;	/* ZIL handle */
-	rangelock_t		zv_rangelock;	/* for range locking */
-	dnode_t			*zv_dn;		/* dnode hold */
-	dev_t			zv_dev;		/* device id */
-	struct gendisk		*zv_disk;	/* generic disk */
-	struct request_queue	*zv_queue;	/* request queue */
-	dataset_kstats_t	zv_kstat;	/* zvol kstats */
-	list_node_t		zv_next;	/* next zvol_state_t linkage */
-	uint64_t		zv_hash;	/* name hash */
-	struct hlist_node	zv_hlink;	/* hash link */
-	kmutex_t		zv_state_lock;	/* protects zvol_state_t */
-	atomic_t		zv_suspend_ref;	/* refcount for suspend */
-	krwlock_t		zv_suspend_lock;	/* suspend lock */
-} zvol_state_t;
 
 // Structure to hold thread local data
 typedef struct {
@@ -141,10 +118,10 @@ zvol_return(struct pt_regs *ctx)
 		__builtin_memcpy(&name, "read", READ_LENGTH);
 	} else if (sync) {
 		__builtin_memcpy(&name, "write", WRITE_LENGTH);
-		__builtin_memcpy(&axis, "sync", WRITE_LENGTH);
+		__builtin_memcpy(&axis, "sync", SYNC_LENGTH);
 	} else {
 		__builtin_memcpy(&name, "write", WRITE_LENGTH);
-		__builtin_memcpy(&axis, "async", WRITE_LENGTH);
+		__builtin_memcpy(&axis, "async", ASYNC_LENGTH);
 	}
 	AGGREGATE_DATA(name, axis, delta, data->bytes);
 	zvol_base_data.delete(&pid);

--- a/bpf/standalone/arc_prefetch.py
+++ b/bpf/standalone/arc_prefetch.py
@@ -270,7 +270,6 @@ flags = ["-include",
          "-I/usr/src/zfs-" + KVER + "/include/",
          "-I/usr/src/zfs-" + KVER + "/include/spl/",
          "-I/usr/src/zfs-" + KVER + "/include/linux",
-         "-DCC_USING_FENTRY",
          "-DNCOUNT_INDEX=" + str(len(ArcCountIndex)),
          "-DNAVERAGE_INDEX=" + str(len(ArcLatencyIndex))] \
          + ArcCountIndex.getCDefinitions() \

--- a/bpf/standalone/txg.py
+++ b/bpf/standalone/txg.py
@@ -349,8 +349,7 @@ b = BPF(text=bpf_text,
                 "-I/usr/src/zfs-" + KVER + "/include/",
                 "-I/usr/src/zfs-" + KVER + "/include/spl",
                 "-I/usr/src/zfs-" + KVER + "/include/",
-                "-I/usr/src/zfs-" + KVER + "/include/linux",
-                "-DCC_USING_FENTRY"])
+                "-I/usr/src/zfs-" + KVER + "/include/linux"])
 
 b.attach_kprobe(event="spa_sync", fn_name="spa_sync_entry")
 b.attach_kretprobe(event="spa_sync", fn_name="spa_sync_return")

--- a/bpf/stbtrace/zio.st
+++ b/bpf/stbtrace/zio.st
@@ -130,8 +130,7 @@ b = BPF(text=bpf_text, cflags=["-include",
                                "/usr/src/zfs-" + KVER + "/zfs_config.h",
                                "-I/usr/src/zfs-" + KVER + "/include/",
                                "-I/usr/src/zfs-" + KVER + "/include/spl/",
-                               "-I/usr/src/zfs-" + KVER + "/include/linux",
-                               "-DCC_USING_FENTRY"])
+                               "-I/usr/src/zfs-" + KVER + "/include/linux"])
 
 b.attach_kretprobe(event="vdev_queue_io_to_issue",
                    fn_name="vdev_queue_issue_return")

--- a/bpf/stbtrace/zpl.st
+++ b/bpf/stbtrace/zpl.st
@@ -178,8 +178,7 @@ b = BPF(text=bpf_text,
                 "-include",
                 "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
                 "-I/usr/src/zfs-" + KVER + "/include/",
-                "-I/usr/src/zfs-" + KVER + "/include/spl/",
-                "-DCC_USING_FENTRY"])
+                "-I/usr/src/zfs-" + KVER + "/include/spl/"])
 
 b.attach_kprobe(event="zfs_read", fn_name="zfs_read_start")
 b.attach_kprobe(event="zfs_write", fn_name="zfs_write_start")

--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -394,8 +394,7 @@ cflags = ["-include",
           "-include",
           "/usr/src/zfs-" + KVER + "/include/spl/sys/types.h",
           "-I/usr/src/zfs-" + KVER + "/include/",
-          "-I/usr/src/zfs-" + KVER + "/include/spl",
-          "-DCC_USING_FENTRY"]
+          "-I/usr/src/zfs-" + KVER + "/include/spl"]
 if script_arg:
     cflags.append("-DOPTARG=\"" + script_arg + "\"")
 


### PR DESCRIPTION
This includes three issues:  

Update estat iscsi, zvol, and zpl scripts. (#55)
LPX-72556 estat warning messages (#52)

It was not a clean merge as the zvol.c script had extra definitions related to [this pr](https://github.com/delphix/performance-diagnostics/pull/42).  That was no longer needed for aws.  Additionally the version of zfs on stage sill uses uio_t so there is not need to change to zfs_uio_t.

I ran all the estat scripts and all compiled and executed though some had no events to record(as expected): 
```
sudo ./estat.py backend-io 1
WARNING: kprobe: blk_start_request - not found
02/03/21 - 22:52:17 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                                   write 
value range                 count ------------- Distribution ------------- 
[700, 800)                      1 |@                                       
[800, 900)                      2 |@@@@@@@                                 
[900, 1000)                     2 |@@@@@@@                                 
[1000, 2000)                    1 |@                                       

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
write                                         5              936            24632               60


                                       iops(/s)  throughput(k/s)
total                                         6               72


sudo ./estat.py iscsi 1
02/03/21 - 22:52:21 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py metaslab-alloc 1
02/03/21 - 22:52:26 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                      /dev/xvdb1, success
value range                 count ------------- Distribution ------------- 
[10, 20)                        2 |@@@@@@@@@@@@@@@@@@@@@                   

   microseconds                                      /dev/xvdc1, success
value range                 count ------------- Distribution ------------- 
[10, 20)                        2 |@@@@@@@@@@@@@@@@@@@@@                   

   microseconds                                      /dev/xvdd1, success
value range                 count ------------- Distribution ------------- 
[10, 20)                        1 |@                                       

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
/dev/xvdb1, success                           2               13               15               72
/dev/xvdc1, success                           2               14               14               72
/dev/xvdd1, success                           1               17                0               36


                                       iops(/s)  throughput(k/s)
total                                         5              180


sudo ./estat.py nfs 1
02/03/21 - 22:52:32 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py nfs-by-client 1
02/03/21 - 22:52:38 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py zio 1
02/03/21 - 22:52:42 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                             write, syncw
value range                 count ------------- Distribution ------------- 
[700, 800)                      2 |@@@@@@                                  
[800, 900)                      4 |@@@@@@@@@@@@@@@@@@                      
[200000, 300000)                1 |@                                       

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
write, syncw                                  7            37943       -937765531               84


                                       iops(/s)  throughput(k/s)
total                                         7               84


sudo ./estat.py zio-queue 1
02/03/21 - 22:52:46 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                             write, syncw
value range                 count ------------- Distribution ------------- 
[0, 10)                         5 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@       

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
write, syncw                                  5                4                4               68


                                       iops(/s)  throughput(k/s)
total                                         5               68


sudo ./estat.py zpl 1
02/03/21 - 22:52:50 UTC

 Tracing enabled... Hit Ctrl-C to end.
sudo ./estat.py zil -c 1
 Tracing enabled... Hit Ctrl-C to end.
^C02/03/21 - 22:53:21 UTC

   latency                                               zfs_write async
value range                 count ------------- Distribution ------------- 
[4, 8)                         13 |@@@                                     
[8, 16)                         5 |@                                       
[16, 32)                       36 |@@@@@@@@                                
[32, 64)                      112 |@@@@@@@@@@@@@@@@@@@@@@@@                
[64, 128)                      17 |@@@@                                    
[128, 256)                      5 |@                                       

                                            avg
zfs_write async                              45


sudo ./estat.py txg
        date                 txg     time since last sync
         |                    |         |   sync time
         |                    |         |        |  (%% pass 1)
         |                    |         |        |    |     highest dirty (%%) 
         |                    |         |        |    |           |  highest throttle delay
         |                    |         |        |    |           |            |      |  avg delay
         v                    v         v        v    v           v            v      v       v
Wed Feb  3 22:53:30 2021       2989     0ms    17ms (91 pass 1)   2MB ( 0)    0us     0ms    0ms
Wed Feb  3 22:53:35 2021       2990  5102ms    14ms (91 pass 1)   3MB ( 0)    0us     0ms    0ms
^Csudo ./estat.py arc_prefetch
02/03/21 - 22:53:45 UTC

prefetch hit count   : 22
   microseconds                                         arc read latency
value range                 count ------------- Distribution ------------- 
[4, 8)                          1 |@                                       
[16, 32)                        1 |@                                       

                                avg latency(us)
arc read latency                             15


^C02/03/21 - 22:53:46 UTC
``` 


