### PR TITLE
Zil issues

### DIFF
--- a/bpf/standalone/zil.py
+++ b/bpf/standalone/zil.py
@@ -115,14 +115,14 @@ static int latency_average_and_histogram(char *name, u64 delta)
     return 0;
 }
 
-int zfs_write_entry(struct pt_regs *ctx, struct inode *ip,
-uio_t *uio, int ioflag)
+int zfs_write_entry(struct pt_regs *ctx, struct znode *zn,
+void *uio, int ioflag)
 {
     u32 tid = bpf_get_current_pid_tgid();
     zil_tid_info_t info = {};
 
     info.write_ts = bpf_ktime_get_ns();
-    zfsvfs_t *zfsvfs = ip->i_sb->s_fs_info;
+    zfsvfs_t *zfsvfs = zn->z_inode.i_sb->s_fs_info;
     objset_t *z_os = zfsvfs->z_os;
     spa_t *spa = z_os->os_spa;
     if (!equal_to_pool(spa->spa_name))


### PR DESCRIPTION
There are two bug fixes.  First, the zil script wouldn't compile on 6.1 due to changes in the zfs_write() paramters.   
```
sudo ./zil.py -c 10
/virtual/main.c:67:1: error: unknown type name 'uio_t'
uio_t *uio, int ioflag)
```
The uio paramter is never referenced so I made that of type void * to make it more robust.   Additionally instead of taking an inode as a parameter a znode is required.  Without this change the filtering by spa name does not work and no data is reported.   

Secondly, the average number of allocations was hardcoded to always return 10 for some unknown reason.   The allocations were being counted but then instead of computing an average, 10 was always used.  The real average is usually just under 1 and so zero is printed(perhaps 10 was added when debugging that and got left in).  Instead of computing an average I switched to displaying the allocation count and calls counts.   I also added a few other events to count that might be interesting.   There also seemed to be some missing zil_commits, those that came from fsyncs.   I added probes for zfs_fsync and  on zil_commits that come from those calls.  

Here is an example of what the script now outputs:
```
sudo ./zil.py -c 10
02/23/21 - 19:42:48 UTC

   latency                                                    allocation
value range                 count ------------- Distribution ------------- 
[4, 8)                          1 |@                                       
[8, 16)                        40 |@@@@@@@@@@@@@@@@@@@@@                   
[16, 32)                       35 |@@@@@@@@@@@@@@@@@@                      

   latency                                                       io wait
value range                 count ------------- Distribution ------------- 
[512, 1K)                       1 |@                                       
[1K, 2K)                       28 |@@@@@@@@@@@@@@@                         
[2K, 4K)                       28 |@@@@@@@@@@@@@@@                         
[4K, 8K)                        9 |@@@@@                                   
[8K, 16K)                       3 |@@                                      
[16K, 32K)                      2 |@                                       
[32K, 64K)                      2 |@                                       
[64K, 128K)                     1 |@                                       
[128K, 256K)                    2 |@                                       

   latency                                                     zfs_fysnc
value range                 count ------------- Distribution ------------- 
[1K, 2K)                       28 |@@@@@@@@@@@@@@@@                        
[2K, 4K)                       27 |@@@@@@@@@@@@@@@@                        
[4K, 8K)                        7 |@@@@                                    
[8K, 16K)                       2 |@                                       
[16K, 32K)                      2 |@                                       
[32K, 64K)                      1 |@                                       
[64K, 128K)                     1 |@                                       
[128K, 256K)                    1 |@                                       

   latency                                               zfs_write async
value range                 count ------------- Distribution ------------- 
[8, 16)                         1 |@                                       
[16, 32)                       29 |@@@@@@@@@@@@@@@                         
[32, 64)                       43 |@@@@@@@@@@@@@@@@@@@@@@                  
[64, 128)                       7 |@@@@                                    

   latency                                                zfs_write sync
value range                 count ------------- Distribution ------------- 
[2K, 4K)                        2 |@@@@@@                                  
[4K, 8K)                        3 |@@@@@@@@@@@                             
[8K, 16K)                       1 |@                                       
[32K, 64K)                      1 |@                                       
[128K, 256K)                    1 |@                                       

   latency                                                    zil_commit
value range                 count ------------- Distribution ------------- 
[1K, 2K)                       29 |@@@@@@@@@@@@@@@                         
[2K, 4K)                       28 |@@@@@@@@@@@@@@@                         
[4K, 8K)                        9 |@@@@@                                   
[8K, 16K)                       3 |@@                                      
[16K, 32K)                      2 |@                                       
[32K, 64K)                      2 |@                                       
[64K, 128K)                     1 |@                                       
[128K, 256K)                    2 |@                                       

                                    avg latency
allocation                                   14
io wait                                    9894
zfs_fysnc                                  8065
zfs_write async                              39
zfs_write sync                            25678
zil_commit                                 9923


                                          count
allocation                                   76
block allocations                            72
io wait                                      76
zfs_fysnc                                    69
zfs_write async                              80
zfs_write sync                                8
zil_commit                                   76

```
 