### PR TITLE
Backport of Zil issues 

### DIFF
--- a/bpf/standalone/zil.py
+++ b/bpf/standalone/zil.py
@@ -115,14 +115,14 @@ static int latency_average_and_histogram(char *name, u64 delta)
     return 0;
 }
 
-int zfs_write_entry(struct pt_regs *ctx, struct inode *ip,
-uio_t *uio, int ioflag)
+int zfs_write_entry(struct pt_regs *ctx, struct znode *zn,
+void *uio, int ioflag)
 {
     u32 tid = bpf_get_current_pid_tgid();
     zil_tid_info_t info = {};
 
     info.write_ts = bpf_ktime_get_ns();
-    zfsvfs_t *zfsvfs = ip->i_sb->s_fs_info;
+    zfsvfs_t *zfsvfs = zn->z_inode.i_sb->s_fs_info;
     objset_t *z_os = zfsvfs->z_os;
     spa_t *spa = z_os->os_spa;
     if (!equal_to_pool(spa->spa_name))


### PR DESCRIPTION
This backport fixes a compilation error in the script and then replaces an average allocation stat with call counts. 

I verified that this runs on 6.0.8.0. 

```
$ sudo ./zil.py
 Tracing enabled... Hit Ctrl-C to end.
^C04/02/21 - 22:50:13 UTC

   latency                                                    allocation
value range                 count ------------- Distribution ------------- 
[8, 16)                        23 |@@@@@@@@@@                              
[16, 32)                       68 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@            
[32, 64)                        4 |@@                                      
[64, 128)                       2 |@                                       

   latency                                                       io wait
value range                 count ------------- Distribution ------------- 
[1K, 2K)                        1 |@                                       
[2K, 4K)                       27 |@@@@@@@@@@@                             
[4K, 8K)                       41 |@@@@@@@@@@@@@@@@@                       
[8K, 16K)                      23 |@@@@@@@@@@                              
[16K, 32K)                      4 |@@                                      

   latency                                                     zfs_fysnc
value range                 count ------------- Distribution ------------- 
[1K, 2K)                        1 |@                                       
[2K, 4K)                       28 |@@@@@@@@@@@@                            
[4K, 8K)                       40 |@@@@@@@@@@@@@@@@                        
[8K, 16K)                      25 |@@@@@@@@@@                              
[16K, 32K)                      4 |@@                                      

   latency                                               zfs_write async
value range                 count ------------- Distribution ------------- 
[16, 32)                       28 |@@@@@@@@@@@                             
[32, 64)                       50 |@@@@@@@@@@@@@@@@@@@                     
[64, 128)                      25 |@@@@@@@@@@                              
[128, 256)                      1 |@                                       

   latency                                                    zil_commit
value range                 count ------------- Distribution ------------- 
[1K, 2K)                        1 |@                                       
[2K, 4K)                       27 |@@@@@@@@@@@                             
[4K, 8K)                       40 |@@@@@@@@@@@@@@@@@                       
[8K, 16K)                      25 |@@@@@@@@@@                              
[16K, 32K)                      4 |@@                                      

                                    avg latency
allocation                                   21
io wait                                    7115
zfs_fysnc                                  7152
zfs_write async                              52
zil_commit                                 7182


                                          count
allocation                                   97
block allocations                            96
io wait                                      96
zfs_fysnc                                    98
zfs_write async                             104
zil_commit                                   97
```