### PR TITLE
DLPX-75470 estat zpl and arc_prefetch scripts need znode parameter

### DIFF
--- a/bpf/standalone/arc_prefetch.py
+++ b/bpf/standalone/arc_prefetch.py
@@ -89,14 +89,14 @@ BPF_HASH(read_latency, hist_lat_key, u64);
 BPF_HASH(read_average, lat_key, average_t);
 BPF_PERCPU_ARRAY(arc_count, u32, NCOUNT_INDEX);
 
-int zfs_read_entry(struct pt_regs *ctx, struct inode *ip)
+int zfs_read_entry(struct pt_regs *ctx, struct znode *zn)
 {
     u32 tid = bpf_get_current_pid_tgid();
     u64 ts = bpf_ktime_get_ns();
     arc_prefetch_info_t info = {ts};
 
     // filter by pool
-    zfsvfs_t *zfsvfs = ip->i_sb->s_fs_info;
+    zfsvfs_t *zfsvfs = zn->z_inode.i_sb->s_fs_info;
     objset_t *z_os = zfsvfs->z_os;
     spa_t *spa = z_os->os_spa;
     if (POOL_COMPARE(spa))


### PR DESCRIPTION
The estat zpl and arc_prefetch scripts do not catch any data due to the inode parameter in zfs_read and zfs_write being replaced by a znode.  

With this change the scripts start producing output: 

```blewis@brad-trunk:~/ws/performance-diagnostics/cmd$ sudo ./estat.py zpl  4
04/23/21 - 21:13:28 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                          zfs_write async
value range                 count ------------- Distribution ------------- 
[20, 30)                        5 |@@@                                     
[30, 40)                        3 |@@                                      
[40, 50)                       27 |@@@@@@@@@@@@@@@@@                       
[50, 60)                       18 |@@@@@@@@@@@                             
[60, 70)                        3 |@@                                      
[70, 80)                        2 |@                                       
[100, 200)                      4 |@@                                      

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
zfs_write async                              15               55              972              132


                                       iops(/s)  throughput(k/s)
total                                        15              132
```

```blewis@brad-trunk:~/ws/performance-diagnostics/cmd$ sudo ./estat.py arc_prefetch 
04/23/21 - 21:14:20 UTC

prefetch hit count   : 1
```
