### PR TITLE
DLPX-75470 estat zpl and arc_prefetch scripts need znode parameter (#61)

### DIFF
--- a/bpf/estat/zpl.c
+++ b/bpf/estat/zpl.c
@@ -46,11 +46,11 @@ equal_to_pool(char *str)
 }
 
 static inline int
-zfs_read_write_entry(io_info_t *info, struct inode *ip, uio_t *uio, int flags)
+zfs_read_write_entry(io_info_t *info, struct znode *zn, zfs_uio_t *uio, int flags)
 {
 	// Essentially ITOZSB, but written explicitly so that BCC can insert
 	// the necessary calls to bpf_probe_read.
-	zfsvfs_t *zfsvfs = ip->i_sb->s_fs_info;
+	zfsvfs_t *zfsvfs = zn->z_inode.i_sb->s_fs_info;
 
 	objset_t *z_os = zfsvfs->z_os;
 	spa_t *spa = z_os->os_spa;
@@ -72,26 +72,26 @@ zfs_read_write_entry(io_info_t *info, struct inode *ip, uio_t *uio, int flags)
 
 // @@ kprobe|zfs_read|zfs_read_entry
 int
-zfs_read_entry(struct pt_regs *ctx, struct inode *ip, uio_t *uio, int flags)
+zfs_read_entry(struct pt_regs *ctx, struct znode *zn, zfs_uio_t *uio, int flags)
 {
 	io_info_t info = {};
 	info.is_write = false;
-	return (zfs_read_write_entry(&info, ip, uio, flags));
+	return (zfs_read_write_entry(&info, zn, uio, flags));
 }
 
 // @@ kprobe|zfs_write|zfs_write_entry
 int
-zfs_write_entry(struct pt_regs *ctx, struct inode *ip, uio_t *uio, int flags)
+zfs_write_entry(struct pt_regs *ctx, struct znode *zn, zfs_uio_t *uio, int flags)
 {
 	io_info_t info = {};
 	info.is_write = true;
-	return (zfs_read_write_entry(&info, ip, uio, flags));
+	return (zfs_read_write_entry(&info, zn, uio, flags));
 }
 
 // @@ kretprobe|zfs_read|zfs_read_write_exit
 // @@ kretprobe|zfs_write|zfs_read_write_exit
 int
-zfs_read_write_exit(struct pt_regs *ctx, struct inode *ip, uio_t *uio)
+zfs_read_write_exit(struct pt_regs *ctx, struct znode *zn, zfs_uio_t *uio)
 {
 	u32 tid = bpf_get_current_pid_tgid();
 	io_info_t *info = io_info_map.lookup(&tid);

--- a/bpf/standalone/arc_prefetch.py
+++ b/bpf/standalone/arc_prefetch.py
@@ -89,14 +89,14 @@ BPF_HASH(read_latency, hist_lat_key, u64);
 BPF_HASH(read_average, lat_key, average_t);
 BPF_PERCPU_ARRAY(arc_count, u32, NCOUNT_INDEX);
 
-int zfs_read_entry(struct pt_regs *ctx, struct inode *ip)
+int zfs_read_entry(struct pt_regs *ctx, struct znode *zn)
 {
     u32 tid = bpf_get_current_pid_tgid();
     u64 ts = bpf_ktime_get_ns();
     arc_prefetch_info_t info = {ts};
 
     // filter by pool
-    zfsvfs_t *zfsvfs = ip->i_sb->s_fs_info;
+    zfsvfs_t *zfsvfs = zn->z_inode.i_sb->s_fs_info;
     objset_t *z_os = zfsvfs->z_os;
     spa_t *spa = z_os->os_spa;
     if (POOL_COMPARE(spa))


### PR DESCRIPTION
Minor merge conflict but this brings 6.0/stage up to date with master. 

I did some quick runs on 6.0/stage to make sure the scripts compile and run: 
```blewis@brad-stage-estat:~/ws/performance-diagnostics/cmd$ sudo ./estat.py zpl -a rpool 5
06/10/21 - 15:17:35 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                           zfs_read async
value range                 count ------------- Distribution ------------- 
[0, 10)                       173 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[10, 20)                        3 |@                                       

   microseconds                                          zfs_write async
value range                 count ------------- Distribution ------------- 
[0, 10)                       401 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@     
[10, 20)                       41 |@@@@                                    
[20, 30)                        5 |@                                       
[30, 40)                        3 |@                                       
[40, 50)                        8 |@                                       
[50, 60)                        3 |@                                       
[70, 80)                        2 |@                                       
[90, 100)                       1 |@                                       

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
zfs_read async                               35                2                5                0
zfs_write async                              92                8               92                0


                                       iops(/s)  throughput(k/s)
total                                       128                0
```

```blewis@brad-stage-estat:~/ws/performance-diagnostics/cmd$ sudo ./estat.py arc_prefetch
06/10/21 - 15:16:41 UTC

06/10/21 - 15:16:46 UTC

prefetch hit count   : 22
   microseconds                                         arc read latency
value range                 count ------------- Distribution ------------- 
[4, 8)                          1 |@                                       
[8, 16)                         1 |@                                       

                                avg latency(us)
arc read latency                             10
```

