### PR TITLE
DLPX-72683 estat utility's help text is missing documentation for arc…

### DIFF
--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -95,6 +95,11 @@ help_msg += """
   The subcommands listed in the following section are stand alone tracers.
   Each has it's own options as detailed below.
 
+  estat arc_prefetch [options]
+      Collect arc_prefetch statistics for 5 second intervals.
+      -h          show txg help message and exit
+      -p POOL     set the pool to monitor (default: domain0)
+
   estat txg [options]
       Collect spa_sync statistics for each txg.
       -h          show txg help message and exit


### PR DESCRIPTION
Here is the updated help text:
```
$ estat.py -h
USAGE: ./estat.py -h
       ./estat.py [prog] [options]

  Tool for running eBPF programs for monitoring performance of various I/O
  related subsystems, focusing on I/O latency. Output can be displayed with
  histograms of I/O broken down by size and type, depending on the provided
  arguments.

OPTIONS:

     -h    show this help message and exit

  The subcommands listed in the following section share common options.
  Each executes the specified tracing program for <duration> seconds,
  displaying various histograms detailing the I/O latency as seen by the
  particular subsystem.

  estat backend-io    [options] <duration>
  estat iscsi         [options] <duration>
  estat metaslab-alloc [options] <duration>
  estat nfs           [options] <duration>
  estat nfs-by-client [options] <duration>
  estat zio           [options] <duration>
  estat zio-queue     [options] <duration>
  estat zpl           [options] <duration>
  estat zvol          [options] <duration>

      -m        monitor mode; emit data periodically
      -M        monitor mode; emit accumulated data periodically
      -a ARG    argument to the BCC script
      -l/-L     enable/disable latency histograms (default: on)
      -z/-Z     enable/disable size histograms (default: off)
      -q/-Q     enable/disable latency histograms by size (default: off)
      -y/-Y     enable/disable the summary output (default: on)
      -t/-T     enable/disable emitting the summary total (default: on)
      -d LEVEL  set BCC debug level
      -e        emit the resulting eBPF script without executing it

  The subcommands listed in the following section are stand alone tracers.
  Each has it's own options as detailed below.

  estat arc_prefetch [options]
      Collect arc_prefetch statistics for 5 second intervals.
      -h          show txg help message and exit
      -p POOL     set the pool to monitor (default: domain0)

  estat txg [options]
      Collect spa_sync statistics for each txg.
      -h          show txg help message and exit
      -c INTERVAL set the collection interval in seconds
      -p POOL     set the pool to monitor (default: domain0)

  estat zil [POOL]
      Provides a breakdown of time spent doing ZIL-related activities, in
      particular the time spent allocating a block and time spent waiting for
      the write I/O to complete. If POOL is not specified, defaults to tracing
      the pool 'domain0'.
```