### PR TITLE
TOOL-11731 performance-diagnostics: build-depends on python3-minimal instead of python-minimal

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,6 @@ Standards-Version: 4.1.2
 
 Package: performance-diagnostics
 Architecture: any
-Depends: python3-bcc, python-minimal, python3-psutil
+Depends: python3-bcc, python3-minimal, python3-psutil
 Description: eBPF-based Performance Diagnostic Tools
   A collection of eBPF-based tools for diagnosing performance issues.


### PR DESCRIPTION
performance-diagnostics actually uses python3 rather than python, so we fix the dependencies accordingly.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5585/
- Verified that estat works on Ubuntu 20.04, which only has python3.