### PR TITLE
TOOL-11951 [Backport of TOOL-11731] performance-diagnostics: build-depends on python3-minimal instead of python-minimal

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,6 @@ Standards-Version: 4.1.2
 
 Package: performance-diagnostics
 Architecture: any
-Depends: python3-bcc, python-minimal, python3-psutil
+Depends: python3-bcc, python3-minimal, python3-psutil
 Description: eBPF-based Performance Diagnostic Tools
   A collection of eBPF-based tools for diagnosing performance issues.


### PR DESCRIPTION
Clean cherry-pick of: #66 

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5832/