### PR TITLE
DLPX-77532 The iscsi estat script needs to be fixed so it reports dat…

### DIFF
--- a/bpf/estat/iscsi.c
+++ b/bpf/estat/iscsi.c
@@ -4,6 +4,24 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+/* 
+ * This tracer provides latency and througphput data for the iscsi target 
+ * read and writes. The latency is measured from entering 
+ * iscsit_process_scsi_cmd() to exiting iscsit_target_response(). The
+ * thread that enters iscsi_process_scsi_cmd() will put an entry on the
+ * request task queue. This entry will be removed from the queue and
+ * processed by another thread which calls iscsi_target_response.
+ * The tracing is performed by three probe functions.
+ * 1. iscsi_target_start - This function saves a timestamp of the entry
+ *    into iscsit_process_scsi_cmd() hashed by a pointer to the iscssi_cmd.
+ * 2. iscsi_target_response - This function serves the purpose of moving
+ *    the timestamp saved by iscsi_target_start to a thread id based hash.
+ *    Also the size and direction are stored in the hash since kretprobes
+ *    do not have access to parameters.
+ * 3. iscsi_target_end - This function retrieves the hashed base data by
+ *    thread id and performs the data aggregation.
+ */
+
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
@@ -20,20 +38,20 @@
 typedef struct {
 	u64 ts;
 	u64 size;
+	u32 direction;
 } iscsi_data_t;
 
 
-BPF_HASH(iscsi_base_data, u64, iscsi_data_t);
+BPF_HASH(iscsi_start_ts, u64, u64);
+BPF_HASH(iscsi_base_data, u32, iscsi_data_t);
 
 // @@ kprobe|iscsit_process_scsi_cmd|iscsi_target_start
 int
 iscsi_target_start(struct pt_regs *ctx, struct iscsi_conn *conn,
     struct iscsi_cmd *cmd, struct iscsi_scsi_req *hdr)
 {
-	iscsi_data_t data = {};
-	data.ts = bpf_ktime_get_ns();
-	data.size = hdr->data_length;
-	iscsi_base_data.update((u64 *) &cmd, &data);
+	u64 ts = bpf_ktime_get_ns();
+	iscsi_start_ts.update((u64 *) &cmd, &ts);
 
 	return (0);
 }
@@ -53,25 +71,48 @@ aggregate_data(iscsi_data_t *data, u64 ts, char *opstr)
 	return (0);
 }
 
-// @@ kprobe|iscsit_build_rsp_pdu|iscsi_target_end
-// @@ kprobe|iscsit_build_datain_pdu|iscsi_target_end
+
+
+// @@ kprobe|iscsit_response_queue|iscsi_target_response
 int
-iscsi_target_end(struct pt_regs *ctx, struct iscsi_cmd *cmd)
+iscsi_target_response(struct pt_regs *ctx, struct iscsi_conn *conn, struct iscsi_cmd *cmd, int state)
+{
+	u32 tid = bpf_get_current_pid_tgid();
+	iscsi_data_t data = {};
+
+	u64 *tsp = iscsi_start_ts.lookup((u64 *) &cmd);
+	if (tsp == 0) {
+		return (0);   // missed issue
+	}
+
+	data.ts = *tsp;
+	data.size = cmd->se_cmd.data_length;
+	data.direction = cmd->data_direction;
+
+	iscsi_base_data.update(&tid, &data);
+	iscsi_start_ts.delete((u64 *) &cmd);
+
+	return (0);
+}
+
+// @@ kretprobe|iscsit_response_queue|iscsi_target_end
+int
+iscsi_target_end(struct pt_regs *ctx)
 {
 	u64 ts = bpf_ktime_get_ns();
-	iscsi_data_t *data = iscsi_base_data.lookup((u64 *) &cmd);
-	u64 delta;
+	u32 tid = bpf_get_current_pid_tgid();
+	iscsi_data_t *data = iscsi_base_data.lookup(&tid);
 
 	if (data == 0) {
 		return (0);   // missed issue
 	}
 
-	if (cmd->data_direction == DMA_FROM_DEVICE) {
+	if (data->direction == DMA_FROM_DEVICE) {
 		aggregate_data(data, ts, READ_STR);
-	} else if (cmd->data_direction & DMA_TO_DEVICE) {
+	} else if (data->direction == DMA_TO_DEVICE) {
 		aggregate_data(data, ts, WRITE_STR);
 	}
-	iscsi_base_data.delete((u64 *) &cmd);
+	iscsi_base_data.delete(&tid);
 
 	return (0);
 }


### PR DESCRIPTION
The script had two issues that were fixed. 
1. The size of the requests was wrong.  Instead of using hdr->data_length, cmd->se_cmd.data_length is being used. 
2. The endpoint for latency calculations was wrong for large reads.   The script previously look to find a function that
    was called when a request was completed.   The function iscsit_response_queue() handles read and writes.  It is
    simpler conceptually to use this as the completion of the function as the endpoint for read and write latency 
    calculations.   However; it adds some complexity as there is no common hash value to use in the entry and exit 
    probes.  The thread id is the only value that a kretprobe has.  So a third probe function is introduced on entry 
    to iscsit_response_queue() to get the entry timestamp hashed by the cmd pointer and rehash it under the thread id. 
    
There are known issues with standard deviation that will be addressed separately.     
    
In testing it produced consistent results that matched the zvol estat output for different sizes.  Here is one example with an 80/20 read/write work and 1M size operations.  
 
 ISCSI
 ```
 sudo estat iscsi -m 30
 ...
09/30/21 - 20:12:28 UTC

   microseconds                                                     read
value range                 count ------------- Distribution ------------- 
[40, 50)                        1 |@                                       
[50, 60)                        5 |@                                       
[60, 70)                        9 |@                                       
[70, 80)                        4 |@                                       
[80, 90)                       15 |@                                       
[90, 100)                       8 |@                                       
[100, 200)                    275 |@                                       
[200, 300)                    521 |@                                       
[300, 400)                    663 |@                                       
[400, 500)                   1236 |@                                       
[500, 600)                   2220 |@                                       
[600, 700)                   3082 |@                                       
[700, 800)                   3852 |@                                       
[800, 900)                   4381 |@                                       
[900, 1000)                  5057 |@                                       
[1000, 2000)                52889 |@@@@@@@@@@                              
[2000, 3000)                40679 |@@@@@@@@                                
[3000, 4000)                27359 |@@@@@@                                  
[4000, 5000)                16649 |@@@@                                    
[5000, 6000)                11580 |@@@                                     
[6000, 7000)                 9110 |@@                                      
[7000, 8000)                 7998 |@@                                      
[8000, 9000)                 6945 |@@                                      
[9000, 10000)                5818 |@@                                      
[10000, 20000)              15969 |@@@                                     
[20000, 30000)               1431 |@                                       
[30000, 40000)                487 |@                                       
[40000, 50000)                179 |@                                       
[50000, 60000)                126 |@                                       
[60000, 70000)                 95 |@                                       
[70000, 80000)                 33 |@                                       
[80000, 90000)                 32 |@                                       
[90000, 100000)                13 |@                                       
[100000, 200000)               47 |@                                       

   microseconds                                                    write
value range                 count ------------- Distribution ------------- 
[400, 500)                      6 |@                                       
[500, 600)                    103 |@                                       
[600, 700)                    364 |@                                       
[700, 800)                    633 |@                                       
[800, 900)                   1019 |@                                       
[900, 1000)                  1267 |@                                       
[1000, 2000)                16323 |@@@@@@@@@@@@                            
[2000, 3000)                10948 |@@@@@@@@@                               
[3000, 4000)                 6286 |@@@@@                                   
[4000, 5000)                 3824 |@@@                                     
[5000, 6000)                 2497 |@@                                      
[6000, 7000)                 1757 |@@                                      
[7000, 8000)                 1344 |@                                       
[8000, 9000)                 1108 |@                                       
[9000, 10000)                 862 |@                                       
[10000, 20000)               5157 |@@@@                                    
[20000, 30000)                741 |@                                       
[30000, 40000)                138 |@                                       
[40000, 50000)                 38 |@                                       
[50000, 60000)                 35 |@                                       
[60000, 70000)                 11 |@                                       
[70000, 80000)                 10 |@                                       
[80000, 90000)                  2 |@                                       
[90000, 100000)                10 |@                                       
[100000, 200000)               81 |@                                       
[200000, 300000)              116 |@                                       

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
read                                       7291             4339         20707354         14004544
write                                      1822             5234         24915778          3502208


                                       iops(/s)  throughput(k/s)
total                                      9112         17496512
```
 
 ZVOL
 ```
 sudo estat zvol -m 30
 ...
 09/30/21 - 20:13:14 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                                     read
value range                 count ------------- Distribution ------------- 
[20, 30)                       83 |@                                       
[30, 40)                       94 |@                                       
[40, 50)                       47 |@                                       
[50, 60)                       25 |@                                       
[60, 70)                       16 |@                                       
[70, 80)                       41 |@                                       
[80, 90)                      260 |@                                       
[90, 100)                     551 |@                                       
[100, 200)                   4336 |@                                       
[200, 300)                   1021 |@                                       
[300, 400)                   1240 |@                                       
[400, 500)                   5001 |@                                       
[500, 600)                   7032 |@@                                      
[600, 700)                   7210 |@@                                      
[700, 800)                   7158 |@@                                      
[800, 900)                   7149 |@@                                      
[900, 1000)                  6981 |@@                                      
[1000, 2000)                51253 |@@@@@@@@@@                              
[2000, 3000)                32153 |@@@@@@                                  
[3000, 4000)                18974 |@@@@                                    
[4000, 5000)                12196 |@@@                                     
[5000, 6000)                 9428 |@@                                      
[6000, 7000)                 7886 |@@                                      
[7000, 8000)                 7057 |@@                                      
[8000, 9000)                 6505 |@@                                      
[9000, 10000)                5504 |@@                                      
[10000, 20000)              14956 |@@@                                     
[20000, 30000)               1130 |@                                       
[30000, 40000)                214 |@                                       
[40000, 50000)                 56 |@                                       
[50000, 60000)                 25 |@                                       
[60000, 70000)                 12 |@                                       
[70000, 80000)                  1 |@                                       
[100000, 200000)                7 |@                                       

   microseconds                                              write, sync
value range                 count ------------- Distribution ------------- 
[300, 400)                      6 |@                                       
[400, 500)                    342 |@                                       
[500, 600)                   1124 |@                                       
[600, 700)                   1662 |@@                                      
[700, 800)                   2085 |@@                                      
[800, 900)                   2247 |@@                                      
[900, 1000)                  2383 |@@                                      
[1000, 2000)                16980 |@@@@@@@@@@@@@                           
[2000, 3000)                 7575 |@@@@@@                                  
[3000, 4000)                 4364 |@@@@                                    
[4000, 5000)                 2874 |@@@                                     
[5000, 6000)                 2092 |@@                                      
[6000, 7000)                 1681 |@@                                      
[7000, 8000)                 1258 |@                                       
[8000, 9000)                 1001 |@                                       
[9000, 10000)                 812 |@                                       
[10000, 20000)               4327 |@@@@                                    
[20000, 30000)                600 |@                                       
[30000, 40000)                 64 |@                                       
[40000, 50000)                 10 |@                                       
[50000, 60000)                  2 |@                                       
[100000, 200000)              105 |@                                       
[200000, 300000)               81 |@                                       

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
read                                       7186             3698         16010449         13797696
write, sync                                1789             4478         20810217          3435200


                                       iops(/s)  throughput(k/s)
total                                      8978         17239168

 ```    
    