### PR TITLE
DLPX-78745 Apply estat iscsi approach to stbtrace script

### DIFF
--- a/bpf/stbtrace/iscsi.st
+++ b/bpf/stbtrace/iscsi.st
@@ -38,8 +38,8 @@ bpf_text += """
 #define OP_NAME_LEN 6
 typedef struct {
     u64 ts;
-    u64 flags;
     u64 size;
+    u32 direction;
 } iscsi_data_t;
 
 // Key structure for scalar aggegations maps
@@ -52,7 +52,8 @@ typedef struct {
 
 HIST_KEY(iscsi_hist_key_t, iscsi_key_t);
 
-BPF_HASH(iscsi_base_data, u64, iscsi_data_t);
+BPF_HASH(iscsi_start_ts, u64, u64);
+BPF_HASH(iscsi_base_data, u32, iscsi_data_t);
 $maps:{map|
 BPF_HASH($map.name$, iscsi_key_t, $map.type$);
 }$
@@ -64,13 +65,31 @@ BPF_HASH($hist.name$, iscsi_hist_key_t, u64);
 int iscsi_target_start(struct pt_regs *ctx, struct iscsi_conn *conn,
                        struct iscsi_cmd *cmd, struct iscsi_scsi_req *hdr)
 {
-    iscsi_data_t data = {};
-    data.ts = bpf_ktime_get_ns();
-    data.flags = hdr->flags;
-    data.size = hdr->data_length;
-    iscsi_base_data.update((u64 *) &cmd, &data);
+        u64 ts = bpf_ktime_get_ns();
+        iscsi_start_ts.update((u64 *) &cmd, &ts);
 
-    return 0;
+        return (0);
+}
+
+int iscsi_target_response(struct pt_regs *ctx, struct iscsi_conn *conn,
+                          struct iscsi_cmd *cmd, int state)
+{
+        u32 tid = bpf_get_current_pid_tgid();
+        iscsi_data_t data = {};
+
+        u64 *tsp = iscsi_start_ts.lookup((u64 *) &cmd);
+        if (tsp == 0) {
+                return (0);   // missed issue
+        }
+
+        data.ts = *tsp;
+        data.size = cmd->se_cmd.data_length;
+        data.direction = cmd->data_direction;
+
+        iscsi_base_data.update(&tid, &data);
+        iscsi_start_ts.delete((u64 *) &cmd);
+
+        return (0);
 }
 
 static int aggregate_data(iscsi_data_t *data, u64 ts, char *opstr)
@@ -99,33 +118,31 @@ static int aggregate_data(iscsi_data_t *data, u64 ts, char *opstr)
     return 0;
 }
 
-int iscsi_target_end(struct pt_regs *ctx, struct iscsi_cmd *cmd)
+int iscsi_target_end(struct pt_regs *ctx)
 {
-    u64 ts = bpf_ktime_get_ns();
-    iscsi_data_t *data = iscsi_base_data.lookup((u64 *) &cmd);
-    u64 delta;
-    iscsi_key_t key = {};
-    char *opstr;
+        u64 ts = bpf_ktime_get_ns();
+        u32 tid = bpf_get_current_pid_tgid();
+        iscsi_data_t *data = iscsi_base_data.lookup(&tid);
 
-    if (data == 0) {
-        return 0;   // missed issue
-    }
+        if (data == 0) {
+                return (0);   // missed issue
+        }
 
-    if (data->flags & ISCSI_FLAG_CMD_READ) {
-        aggregate_data(data, ts, READ_STR);
-    } else if (data->flags & ISCSI_FLAG_CMD_WRITE) {
-        aggregate_data(data, ts, WRITE_STR);
-    }
-    iscsi_base_data.delete((u64 *) &cmd);
+        if (data->direction == DMA_FROM_DEVICE) {
+                aggregate_data(data, ts, READ_STR);
+        } else if (data->direction == DMA_TO_DEVICE) {
+                aggregate_data(data, ts, WRITE_STR);
+        }
+        iscsi_base_data.delete(&tid);
 
-    return 0;
+        return (0);
 }
-
 """  # noqa: W293
 b = BPF(text=bpf_text)
 
 b.attach_kprobe(event="iscsit_process_scsi_cmd", fn_name="iscsi_target_start")
-b.attach_kprobe(event="iscsit_build_rsp_pdu", fn_name="iscsi_target_end")
+b.attach_kprobe(event="iscsit_response_queue", fn_name="iscsi_target_response")
+b.attach_kretprobe(event="iscsit_response_queue", fn_name="iscsi_target_end")
 
 helper = BCCHelper(b, BCCHelper.ANALYTICS_PRINT_MODE)
 $maps:{map|


### PR DESCRIPTION
Recently the estat iscsi script was overhauled.  The stbtrace script suffers from some of the same issues that the estat script had, most notably missing write events and reporting incorrect throughput.  This commit rewrites the probe functions in the iscsi stbtrace script.  It uses the same probe functions as the estat version.  They have different aggregate_data functions.  

For testing the output was compared to the estat output to verify it's correctness:  
```
$ sudo stbtrace iscsi 
{"t":"1639163735", "op":"read", "count":"4114", "avgLatency":"3892728", "throughput":"269090816", "latency":"{200000,7},{300000,20},{400000,35},{500000,49},{600000,90},{700000,121},{800000,165},{900000,156},{1000000,158},{2000000,1299},{3000000,643},{4000000,303},{5000000,165},{6000000,120},{7000000,107},{8000000,70},{9000000,67},{10000000,81},{20000000,221},{30000000,62},{40000000,40},{50000000,17},{60000000,1},{70000000,1}", "size":"{131071,3969}"}

{"t":"1639163735", "op":"write", "count":"4159", "avgLatency":"3195912", "throughput":"272171008", "latency":"{500000,3},{600000,11},{700000,46},{800000,79},{900000,160},{1000000,174},{2000000,1751},{3000000,769},{4000000,346},{5000000,170},{6000000,108},{7000000,75},{8000000,52},{9000000,59},{10000000,38},{20000000,137},{30000000,51},{40000000,8},{50000000,10}", "size":"{131071,4038}"}
```

```
$ sudo estat iscsi 10
12/10/21 - 19:15:12 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                                     read
value range                 count ------------- Distribution ------------- 
[50, 60)                        1 |@                                       
[60, 70)                        6 |@                                       
[70, 80)                        1 |@                                       
[80, 90)                        3 |@                                       
[90, 100)                       1 |@                                       
[100, 200)                    168 |@                                       
[200, 300)                    401 |@                                       
[300, 400)                    556 |@                                       
[400, 500)                   1209 |@@                                      
[500, 600)                   1952 |@@                                      
[600, 700)                   2568 |@@@                                     
[700, 800)                   2788 |@@@                                     
[800, 900)                   2762 |@@@                                     
[900, 1000)                  2711 |@@@                                     
[1000, 2000)                16555 |@@@@@@@@@@@@@@@                         
[2000, 3000)                 5768 |@@@@@                                   
[3000, 4000)                 2070 |@@                                      
[4000, 5000)                 1062 |@                                       
[5000, 6000)                  811 |@                                       
[6000, 7000)                  886 |@                                       
[7000, 8000)                  656 |@                                       
[8000, 9000)                  545 |@                                       
[9000, 10000)                 456 |@                                       
[10000, 20000)               1774 |@@                                      
[20000, 30000)                579 |@                                       
[30000, 40000)                182 |@                                       
[40000, 50000)                 63 |@                                       
[50000, 60000)                 56 |@                                       
[60000, 70000)                 24 |@                                       
[70000, 80000)                 14 |@                                       
[80000, 90000)                  3 |@                                       
[90000, 100000)                 2 |@                                       
[100000, 200000)               11 |@                                       

   microseconds                                                    write
value range                 count ------------- Distribution ------------- 
[400, 500)                     44 |@                                       
[500, 600)                    308 |@                                       
[600, 700)                    858 |@                                       
[700, 800)                   1768 |@@                                      
[800, 900)                   2450 |@@@                                     
[900, 1000)                  2954 |@@@                                     
[1000, 2000)                23513 |@@@@@@@@@@@@@@@@@@@@@                   
[2000, 3000)                 6351 |@@@@@@                                  
[3000, 4000)                 1925 |@@                                      
[4000, 5000)                 1060 |@                                       
[5000, 6000)                  658 |@                                       
[6000, 7000)                  497 |@                                       
[7000, 8000)                  410 |@                                       
[8000, 9000)                  370 |@                                       
[9000, 10000)                 408 |@                                       
[10000, 20000)               2227 |@@                                      
[20000, 30000)                586 |@                                       
[30000, 40000)                204 |@                                       
[40000, 50000)                 63 |@                                       
[50000, 60000)                 38 |@                                       
[60000, 70000)                 60 |@                                       
[70000, 80000)                 15 |@                                       
[90000, 100000)                 3 |@                                       
[100000, 200000)                3 |@                                       
[200000, 300000)               64 |@                                       

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
read                                       4664             2968         25795568           298521
write                                      4683             3453         27252713           299756


                                       iops(/s)  throughput(k/s)
total                                      9348           598278
```
