### PR TITLE
DLPX-78888 [Backport of DLPX-78812 to 6.0.12] Disk IO analytics colle…

### DIFF
--- a/bpf/estat/backend-io.c
+++ b/bpf/estat/backend-io.c
@@ -44,7 +44,7 @@ disk_io_start(struct pt_regs *ctx, struct request *reqp)
 	return (0);
 }
 
-// @@ kprobe|blk_account_io_completion|disk_io_done
+// @@ kprobe|blk_account_io_done|disk_io_done
 int
 disk_io_done(struct pt_regs *ctx, struct request *reqp)
 {

--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -128,7 +128,7 @@ b = BPF(text=bpf_text)
 if BPF.get_kprobe_functions(b'blk_start_request'):
     b.attach_kprobe(event="blk_start_request", fn_name="disk_io_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="disk_io_start")
-b.attach_kprobe(event="blk_account_io_completion", fn_name="disk_io_done")
+b.attach_kprobe(event="blk_account_io_done", fn_name="disk_io_done")
 
 
 helper = BCCHelper(b, BCCHelper.ANALYTICS_PRINT_MODE)


### PR DESCRIPTION
Clean cherry-pick.  

stbtrace and estat run on aws and dcol1 engines.  