### PR TITLE
DLPX-78891 stbtrace zpl fails due to uid_t

### DIFF
--- a/bpf/stbtrace/zpl.st
+++ b/bpf/stbtrace/zpl.st
@@ -28,7 +28,8 @@ bpf_text += """
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
 
-#include <sys/uio.h>
+#include <sys/xvattr.h>
+#include <sys/zfs_znode.h>
 
 // Definitions for this script
 #define READ_STR "read"
@@ -67,9 +68,9 @@ BPF_HASH($hist.name$, zpl_hist_key_t, u64);
 }$
 
 // Probe functions to initialize thread local data
-int zfs_read_start(struct pt_regs *ctx, void *inode, uio_t *uio)
+int zfs_read_start(struct pt_regs *ctx, struct znode *zn, zfs_uio_t *uio,
+   int flags)
 {
-
     u32 pid = bpf_get_current_pid_tgid();
     zpl_data_t data = {};
     data.ts = bpf_ktime_get_ns();
@@ -81,9 +82,9 @@ int zfs_read_start(struct pt_regs *ctx, void *inode, uio_t *uio)
 }
 
 // Probe functions to initialize thread local data
-int zfs_write_start(struct pt_regs *ctx, void *inode, uio_t *uio)
+int zfs_write_start(struct pt_regs *ctx, struct znode *zn, zfs_uio_t *uio,
+    int flags)
 {
-
     u32 pid = bpf_get_current_pid_tgid();
     zpl_data_t data = {};
     data.ts = bpf_ktime_get_ns();


### PR DESCRIPTION
Akash found this while working on new stbtrace tests. 
```
$ sudo python3 /usr/bin/stbtrace zpl
/virtual/main.c:51:54: error: unknown type name 'uio_t'; did you mean 'uid_t'?
int zfs_read_start(struct pt_regs *ctx, void *inode, uio_t *uio)
                                                     ^~~~~
                                                     uid_t
include/linux/types.h:32:26: note: 'uid_t' declared here
typedef __kernel_uid32_t        uid_t;
                                ^
/virtual/main.c:57:20: error: member reference base type 'uid_t' (aka 'unsigned int') is not a structure or union
    data.size = uio->uio_resid;
                ~~~^ ~~~~~~~~~
/virtual/main.c:65:55: error: unknown type name 'uio_t'; did you mean 'uid_t'?
int zfs_write_start(struct pt_regs *ctx, void *inode, uio_t *uio)
                                                      ^~~~~
                                                      uid_t
include/linux/types.h:32:26: note: 'uid_t' declared here
typedef __kernel_uid32_t        uid_t;
                                ^
/virtual/main.c:71:20: error: member reference base type 'uid_t' (aka 'unsigned int') is not a structure or union
    data.size = uio->uio_resid;
                ~~~^ ~~~~~~~~~
4 errors generated.
Failed to compile BPF module <text>
```

The estat script was previously updated (sadly the stbtrace counterpart was neglected at that time). 

I verfied that this compiles and give reasonable data: 
aws
```
$ sudo cmd/stbtrace.py zpl
{"t":"1640198205", "op":"write", "sync":"0", "cached":"-1", "count":"5", "avgLatency":"48221", "throughput":"49152", "latency":"{30000,1},{50000,3},{70000,1}", "size":"{16383,4},{32767,1}"}

{"t":"1640198206", "op":"write", "sync":"0", "cached":"-1", "count":"5", "avgLatency":"47128", "throughput":"49152", "latency":"{40000,1},{50000,3},{60000,1}", "size":"{16383,4},{32767,1}"}

{"t":"1640198207", "op":"write", "sync":"0", "cached":"-1", "count":"109", "avgLatency":"17016", "throughput":"59316", "latency":"{10000,83},{20000,9},{30000,1},{50000,5},{60000,4},{70000,1},{80000,2},{90000,1},{100000,1},{200000,2}", "size":"{63,24},{127,2},{255,52},{511,26},{16383,5}"}

{"t":"1640198207", "op":"read", "sync":"-1", "cached":"1", "count":"120", "avgLatency":"2230", "throughput":"88176", "latency":"{10000,119},{90000,1}", "size":"{31,4},{127,4},{511,12},{1023,100}"}
...
```
dcol1
```
$ sudo cmd/stbtrace.py zpl
{"t":"1640197738", "op":"write", "sync":"0", "cached":"-1", "count":"1", "avgLatency":"48101", "throughput":"8192", "latency":"{50000,1}", "size":"{16383,1}"}

{"t":"1640197739", "op":"write", "sync":"0", "cached":"-1", "count":"257", "avgLatency":"9362", "throughput":"81685", "latency":"{10000,211},{20000,31},{30000,3},{40000,1},{50000,9},{70000,2}", "size":"{63,49},{127,41},{255,110},{511,52},{16383,5}"}

{"t":"1640197739", "op":"read", "sync":"-1", "cached":"1", "count":"176", "avgLatency":"1983", "throughput":"110160", "latency":"{10000,174},{20000,2}", "size":"{31,12},{127,12},{511,36},{1023,116}"}
...
```