### PR TITLE
CP-8403 Adding Telegraf-based metric collection.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,3 +22,6 @@ override_dh_auto_install:
 	dh_install build/cmd/* /usr/bin
 	dh_install lib/* /usr/share/performance-diagnostics/lib
 	dh_install bpf/* /usr/share/performance-diagnostics/bpf
+	dh_install telegraf/delphix-telegraf-service telegraf/perf_playbook /usr/bin
+	dh_install telegraf/delphix-telegraf.service /lib/systemd/system
+	dh_install telegraf/telegraf* telegraf/*.sh /etc/telegraf

--- a/telegraf/delphix-telegraf-service
+++ b/telegraf/delphix-telegraf-service
@@ -1,0 +1,34 @@
+#!/bin/bash
+BASE_CONFIG=/etc/telegraf/telegraf.base
+DOSE_INPUTS=/etc/telegraf/telegraf.inputs.dose
+PLAYBOOK_INPUTS=/etc/telegraf/telegraf.inputs.playbook
+PLAYBOOK_FLAG=/etc/telegraf/PLAYBOOK_ENABLED
+TELEGRAF_CONFIG=/etc/telegraf/telegraf.conf
+
+
+function engine_is_object_based() {
+	zdb -C | grep "type: 'object_store'" >/dev/null
+	[[ "$?" == "0" ]]
+}
+
+function playbook_is_enabled() {
+	[[ -f $PLAYBOOK_FLAG ]]
+}
+
+rm -f $TELEGRAF_CONFIG
+
+if engine_is_object_based; then
+	if playbook_is_enabled; then
+		cat $PLAYBOOK_INPUTS $DOSE_INPUTS $BASE_CONFIG > $TELEGRAF_CONFIG
+	else
+		cat $DOSE_INPUTS $BASE_CONFIG > $TELEGRAF_CONFIG
+	fi
+else
+	if playbook_is_enabled; then
+		cat $PLAYBOOK_INPUTS $BASE_CONFIG > $TELEGRAF_CONFIG
+	else
+		cat $BASE_CONFIG > $TELEGRAF_CONFIG
+	fi
+fi
+
+/usr/bin/telegraf -config $TELEGRAF_CONFIG

--- a/telegraf/delphix-telegraf.service
+++ b/telegraf/delphix-telegraf.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Delphix Telegraf Metric Collection Agent
+Documentation=https://github.com/influxdata/telegraf
+PartOf=delphix.target
+After=delphix-platform.service
+PartOf=delphix-platform.service
+
+[Service]
+EnvironmentFile=-/etc/default/telegraf
+User=root
+ExecStart=/usr/bin/delphix-telegraf-service
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartForceExitStatus=SIGPIPE
+KillMode=control-group
+
+[Install]
+WantedBy=delphix.target

--- a/telegraf/nfs-threads.sh
+++ b/telegraf/nfs-threads.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+nfs_threads | egrep --line-buffered -v "thr"
+

--- a/telegraf/perf_playbook
+++ b/telegraf/perf_playbook
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 by Delphix. All rights reserved.
+#
+# Script that enables and, disables the Performance Playbook configuration for 
+# metric collection by Telegraf
+#
+
+PLAYBOOK_FLAG=/etc/telegraf/PLAYBOOK_ENABLED
+
+#
+# Make sure this can only be run as root.
+#
+function die() {
+	echo -e "$(date +%T:%N:%z): $(basename $0): $*" >&2
+	exit 1
+}
+
+[[ $EUID -ne 0 ]] && die "must be run as root"
+
+#
+# Process command.
+#
+
+function usage() {
+	echo "$(basename $0): $*" >&2
+	echo "Usage: $(basename $0) [enable|disable]"
+	exit 2
+}
+
+function enable_playbook() {
+	date
+	echo "Enabling Performance Playbook Metrics"
+	touch $PLAYBOOK_FLAG
+	systemctl restart delphix-telegraf
+}
+
+function disable_playbook() {
+	date
+	echo "Disabling Performance Playbook Metrics"
+	rm -rf $PLAYBOOK_FLAG
+	systemctl restart delphix-telegraf
+}
+
+if [[ $# -ne 1 ]]; then
+	usage
+fi
+
+case "$1" in
+enable) enable_playbook ;;
+disable) disable_playbook ;;
+*) usage ;;
+esac

--- a/telegraf/telegraf.base
+++ b/telegraf/telegraf.base
@@ -1,0 +1,131 @@
+# Telegraf Configuration
+#
+# Configuration for telegraf agent
+[agent]
+  interval = "10s"
+  round_interval = true
+  flush_interval = "10s"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+
+###############################################################################
+#                            OUTPUT PLUGINS                                   #
+###############################################################################
+# Define the main metric output file, excluding aggregated stats and 
+# Performance Playbook (estat) data.
+[[outputs.file]]
+  files = ["/var/log/telegraf/metrics.json"]
+  rotation_max_size = "50MB"
+  rotation_max_archives = 9
+  data_format = "json"
+  namedrop = ["*estat_*", "agg_*", "zfs", "zpool*", "zcache*"]
+
+# Define output file for ZFS related metrics
+[[outputs.file]]
+  files = ["/var/log/telegraf/metrics_zfs.json"]
+  rotation_max_size = "30MB"
+  rotation_max_archives = 5
+  data_format = "json"
+  namepass = ["zpool*", "zcache*", "zfs"]
+
+# Define output file for Performance Playbook (estat) metrics
+[[outputs.file]]
+  files = ["/var/log/telegraf/metrics_estat.json"]
+  rotation_max_size = "30MB"
+  rotation_max_archives = 5
+  data_format = "json"
+  namepass = ["*estat_*"]
+
+# Define output file for aggregate statistics
+[[outputs.file]]
+  files = ["/var/log/telegraf/metric_aggregates.json"]
+  rotation_max_size = "30MB"
+  rotation_max_archives = 5
+  data_format = "json"
+  namepass = ["agg_*"]
+
+# Enable Live Monitoring, intended for internal use:
+#[[outputs.influxdb]]
+#  urls = ["http://dbsvr.company.com:8086"]
+#  database = "live_metrics"
+#  skip_database_creation = true
+#  data_format = "influx"
+
+###############################################################################
+#                            INPUT PLUGINS                                    #
+###############################################################################
+
+# Get CPU usage
+[[inputs.cpu]]
+  percpu = true
+  totalcpu = true
+  collect_cpu_time = false
+  report_active = false
+  fieldpass = ["usage*"]
+
+# Get mount point stats
+[[inputs.disk]]
+  mount_points = ["/","/domain0"]
+
+# Get disk I/O stats
+[[inputs.diskio]]
+
+# Track stats for the current metric files
+[[inputs.filestat]]
+  files = ["/var/log/telegraf/metrics.json",
+  	   "/var/log/telegraf/metrics_estat.json",
+  	   "/var/log/telegraf/metrics_zfs.json",
+  	   "/var/log/telegraf/metric_aggregates.json"]
+
+# Get Memory stats
+[[inputs.mem]]
+
+# Get some network interface stats
+[[inputs.net]]
+  fieldpass = ["tcp*","bytes*","packets*","err*","drop*"]
+
+# Track CPU and Memory for the "delphix-mgmt" service (and children).
+[[inputs.procstat]]
+  systemd_unit = "delphix-mgmt.service"
+  include_systemd_children = true
+  namedrop = ["procstat_lookup"]
+  fieldpass = ["memory_usage", "cpu_usage", "memory_rss"]
+
+# Track CPU and Memory for the "zfs-object-agent" service (and children).
+[[inputs.procstat]]
+  systemd_unit = "zfs-object-agent.service"
+  include_systemd_children = true
+  namedrop = ["procstat_lookup"]
+  fieldpass = ["memory_usage", "cpu_usage", "memory_rss"]
+
+# Get process counts
+[[inputs.processes]]
+
+# Get swap memory usage
+[[inputs.swap]]
+
+# Get misc 'other' stats (load and uptime)
+[[inputs.system]]
+
+# ZFS kstats (arcstat, abdstat, zfetch, etc)
+[[inputs.zfs]]
+  interval = "1m"
+
+# Detailed ZFS pool metrics from "zpool_influxdb" (noisy)
+#[[inputs.exec]]
+#  commands = ["/usr/lib/x86_64-linux-gnu/zfs/zpool_influxdb"]
+#  data_format = "influx"
+
+###############################################################################
+#                       AGGREGATION PLUGINS                                   #
+###############################################################################
+# Filtered aggregate statistics
+# Calculate Min, Max, Mean, Std Deviation every hour for selected metrics:
+# 	CPU Usage (%idle)
+[[aggregators.basicstats]]
+  period = "1h"
+  drop_original = false
+  stats = ["min", "max", "mean", "stdev"]
+  name_prefix = "agg_"
+  namepass = ["cpu","disk","diskio","mem","net","processes","system","swap"]
+

--- a/telegraf/telegraf.inputs.dose
+++ b/telegraf/telegraf.inputs.dose
@@ -1,0 +1,46 @@
+#######################  DOSE/zcache Metrics  ################################
+[[inputs.execd]]
+  command = ["/etc/telegraf/zcache-stats.sh"]
+  name_override = "zcache_stats"
+  signal = "none"
+  data_format = "csv"
+  csv_skip_columns = 1
+  csv_column_names = ["cache_lookup_count","idx_access_pendch","idx_access_entry","idx_access_chunk",
+                        "idx_access_disk","cache_hits_count","cache_hits_bytes","cache_hits_ratio",
+                        "cache_insert_count","cache_insert_bytes","insert_source_read","insert_source_write",
+                        "insert_source_specr","insert_drops_buffer","insert_drops_alloc","bufbytes_used_demand",
+                        "bufbytes_used_spec","cache_other_evicts","cache_other_pending","alloc_alloc",
+                        "alloc_avail","alloc_free_space","alloc_free_slabs"]
+  csv_column_types = ["int","int","int","int","int","int","int","int","int","int","int","int","int",
+                        "int","int","int","int","int","int","int","int","int","int"]
+  csv_delimiter = "\t"
+  csv_trim_space = true
+
+
+[[inputs.execd]]
+  command = ["/etc/telegraf/zpool-iostat-o.sh"]
+  name_override = "zpool_iostat-o"
+  signal = "none"
+  data_format = "csv"
+  csv_column_names = ["pool","agent_io_op_read","agent_io_op_write","agent_io_tput_read",
+			"agent_io_tput_write","store_data_op_get","store_data_op_put","store_data_tput_get",
+			"store_data_tput_put","store_metadata_op_get","store_metadata_op_put",
+			"store_metadata_tput_get","store_metadata_tput_put","store_reclaim_op_get",
+			"store_reclaim_op_put","store_reclaim_tput_get","store_reclaim_tput_put","object_del"]
+  csv_column_types = ["string","int","int","int","int","int","int","int","int","int","int","int","int",
+			"int","int","int","int","int"]
+  csv_tag_columns = ["pool"]
+  csv_delimiter = " "
+  csv_trim_space = true
+
+
+[[inputs.exec]]
+  interval = "1h"
+  commands = ["/usr/sbin/zcache hits --json"]
+  name_override = "zcache_hits"
+  data_format = "json"
+  json_string_fields = ["start_time"]
+
+
+# End of DOSE/zcache section
+

--- a/telegraf/telegraf.inputs.playbook
+++ b/telegraf/telegraf.inputs.playbook
@@ -1,0 +1,149 @@
+##############################################################################
+# Performance Playbook (estat, nfs_threads) collection 
+
+# Collect output from "estat nfs -jm 10"
+[[inputs.execd]]
+  command = ["estat", "nfs", "-jm", "10"]
+  name_override = "estat_nfs"
+  signal = "none"
+  data_format = "json"
+  tag_keys = [
+    "name",
+    "axis"
+  ]
+  json_string_fields = ["iops(/s)", "avg latency(us)", "stddev(us)", "throughput(k/s)", "microseconds"]
+
+# Collect output from "estat iscsi -jm 10"
+[[inputs.execd]]
+  command = ["estat", "iscsi", "-jm", "10"]
+  name_override = "estat_iscsi"
+  signal = "none"
+  data_format = "json"
+  tag_keys = [
+    "name",
+    "axis"
+  ]
+  json_string_fields = ["iops(/s)", "avg latency(us)", "stddev(us)", "throughput(k/s)", "microseconds"]
+
+# Collect output from "estat zpl -jm 10"
+[[inputs.execd]]
+  command = ["estat", "zpl", "-jm", "10"]
+  name_override = "estat_zpl"
+  signal = "none"
+  data_format = "json"
+  tag_keys = [
+    "name",
+    "axis"
+  ]
+  json_string_fields = ["iops(/s)", "avg latency(us)", "stddev(us)", "throughput(k/s)", "microseconds"]
+
+# Collect output from "estat backend-io -jm 10"
+[[inputs.execd]]
+  command = ["estat", "backend-io", "-jm", "10"]
+  name_override = "estat_backend-io"
+  signal = "none"
+  data_format = "json"
+  tag_keys = [
+    "name",
+    "axis"
+  ]
+  json_string_fields = ["iops(/s)", "avg latency(us)", "stddev(us)", "throughput(k/s)", "microseconds"]
+
+# Collect output from "estat zvol -jm 10"
+[[inputs.execd]]
+  command = ["estat", "zvol", "-jm", "10"]
+  name_override = "estat_zvol"
+  signal = "none"
+  data_format = "json"
+  tag_keys = [
+    "name",
+    "axis"
+  ]
+  json_string_fields = ["iops(/s)", "avg latency(us)", "stddev(us)", "throughput(k/s)", "microseconds"]
+
+# Collect output from "estat zio -jm 10"
+[[inputs.execd]]
+  command = ["estat", "zio", "-jm", "10"]
+  name_override = "estat_zio"
+  signal = "none"
+  data_format = "json"
+  tag_keys = [
+    "name",
+    "axis"
+  ]
+  json_string_fields = ["iops(/s)", "avg latency(us)", "stddev(us)", "throughput(k/s)", "microseconds"]
+
+# Collect output from "estat metaslab-alloc -jm 10"
+#[[inputs.execd]]
+#  command = ["estat", "metaslab-alloc", "-jm", "10"]
+#  name_override = "estat_metaslab-alloc"
+#  signal = "none"
+#  data_format = "json"
+#  tag_keys = [
+#    "name",
+#    "axis"
+#  ]
+#  json_string_fields = ["iops(/s)", "avg latency(us)", "stddev(us)", "throughput(k/s)", "microseconds"]
+
+# Collect output from "nfs_threads"
+[[inputs.execd]]
+  command = ["/etc/telegraf/nfs-threads.sh"]
+  name_override = "nfs_threads"
+  signal = "none"
+  data_format = "csv"
+  csv_skip_columns = 2
+  csv_column_names = ["packets","sockets","woken","used","metadata","riops","rtput","wiops","wtput"]
+  csv_column_types = ["int", "int", "int", "int", "int", "float","string","float","string"]
+  csv_delimiter = " "
+  csv_trim_space = true
+
+# End of Playbook section
+##############################################################################
+
+###############################################################################
+#                         PROCESSOR PLUGINS                                   #
+###############################################################################
+# Convert strings from estat into integer values so they don't get dropped
+[[processors.converter]]
+  [processors.converter.fields]
+    integer = ["iops(/s)", "avg latency(us)", "stddev(us)", "throughput(k/s)"]
+
+# The estat output contains a nested latency histogram, so we need to 
+# parse that out as a new array metric rather than a non-JSON string.
+#
+# From this:
+#	"microseconds":"{20000,5},{30000,15},{40000,3},{50000,24}"
+# to this:
+#	"microseconds":"{20000:5,30000:15,40000:3,50000:24}"
+#
+# Clone the original so we have a "new" metric with a "hist_" name prefix
+[[processors.clone]]
+  order = 1
+  name_prefix = "hist_"
+  namepass = ["estat_*"]
+
+# Rewrite the histograms for the "hist_estat_*" metrics as JSON objects
+[[processors.regex]]
+  order = 2
+  namepass = ["hist_estat_*"]
+  [[processors.regex.fields]]
+    key = "microseconds"
+    pattern = "{(\\d+),(\\d+)}"
+    replacement = "\"${1}\":${2}"
+  [[processors.regex.fields]]
+    key = "microseconds"
+    pattern = ".*"
+    replacement = "{$0}"
+
+# Now parse out the arrays for "hist_estat_*" metrics
+[[processors.parser]]
+  order = 3
+  merge = "override"
+  parse_fields = ["microseconds"]
+  drop_original = false
+  data_format = "json"
+  namepass = ["hist_estat_*"]
+  fieldpass = ["microseconds"]
+
+# End of Processor section
+##############################################################################

--- a/telegraf/zcache-stats.sh
+++ b/telegraf/zcache-stats.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+zcache stats -ap 10 | egrep --line-buffered -v "\-"
+

--- a/telegraf/zpool-iostat-o.sh
+++ b/telegraf/zpool-iostat-o.sh
@@ -1,0 +1,3 @@
+#!/bin/bash 
+zpool iostat -opy domain0 10 | egrep --line-buffered -v "object|put|\-"
+


### PR DESCRIPTION
Initial addition of configuration and control files to enable performance metric collection using the Telegraf agent.
See also IDEA-2835 : Improving Support Bundle Performance Metrics

Includes:
- Service definition and startup script for "delphix-telegraf"
- Modified version of "estat" adding JSON output via a "-j" option
- A "perf_playbook" wrapper script to enable/disable enhanced collection
- Configuration file sections (combined on startup)
- Simple wrappers to facilitate parsing of "nfs_threads", "zpool iostat -o",
and "zcache stats -a" outputs

The service starts with a "base" set of metrics, but will include Object Storage
metrics when it is detected, and will include Performance Playbook commands
if that has been enabled (manually). The config is reassembled each startup.

File paths intended:

/opt/delphix/server/bin/delphix-telegraf-service
/lib/systemd/system/delphix-telegraf.service
/usr/bin/estat
/etc/telegraf/nfs-threads.sh
/opt/delphix/server/bin/perf_playbook
/etc/telegraf/telegraf.base
/etc/telegraf/telegraf.inputs.dose
/etc/telegraf/telegraf.inputs.playbook
/etc/telegraf/zcache-stats.sh
/etc/telegraf/zpool-iostat-o.sh

This configuration records 3 output files (rotated on size) for main metrics,
aggregate statistics (min,max,mean,stddev) and Playbook outputs to enable
independent retention periods.

