### PR TITLE
Revert "TOOL-13515 [Backport of TOOL-13470 to 6.0.14.0] add telegraf dependency to the performance-diagnostic package (#82)"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,6 @@ Standards-Version: 4.1.2
 
 Package: performance-diagnostics
 Architecture: any
-Depends: python3-bcc, python3-minimal, python3-psutil, telegraf
+Depends: python3-bcc, python3-minimal, python3-psutil
 Description: eBPF-based Performance Diagnostic Tools
   A collection of eBPF-based tools for diagnosing performance issues.


### PR DESCRIPTION
This reverts commit 8cd3f7a28d08dac751a3abd159acabfa8432ea28.