### PR TITLE
APIGW-10925 Extend support bundle data with historical docker stats

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: "3.10"
     - name: flake8
       run: |
         python -m pip install --upgrade pip

--- a/cmd/nfs_threads.py
+++ b/cmd/nfs_threads.py
@@ -153,7 +153,7 @@ def print_line(interval):
     if e1 or e2 or e3:
         return
 
-    while(not sleep(interval)):
+    while not sleep(interval):
         nextCpuTime, e1 = cpu_time(pids)
         nextPackets, nextEnqueued, nextWoken, e2 = pool_stats()
         nextRB, nextWB, nextRO, nextWO, nextMeta, e3 = nfs_stats()

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,6 @@ Standards-Version: 4.1.2
 
 Package: performance-diagnostics
 Architecture: any
-Depends: python3-bcc, python3-minimal, python3-psutil, telegraf
+Depends: python3-bcc, python3-minimal, python3-psutil, telegraf, docker.io
 Description: eBPF-based Performance Diagnostic Tools
   A collection of eBPF-based tools for diagnosing performance issues.

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+USER="telegraf"
+GROUP="docker"
+
+# Ensure user and group exist
+if ! id "$USER" &>/dev/null; then
+	echo "Error: User '$USER' does not exist" >&2
+	exit 1
+fi
+
+if ! getent group "$GROUP" &>/dev/null; then
+	echo "Error: Group '$GROUP' does not exist" >&2
+	exit 1
+fi
+
+# Add user to the group if not already a member
+if ! groups "$USER" | grep -q "\b$GROUP\b"; then
+	if usermod -a -G "$GROUP" "$USER"; then
+		echo "User '$USER' added to group '$GROUP'."
+	else
+		echo "Error: Failed to add user '$USER' to group '$GROUP'" >&2
+		exit 1
+	fi
+fi
+
+exit 0

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+USER="telegraf"
+GROUP="docker"
+
+# Ensure user and group exist
+if ! id "$USER" &>/dev/null; then
+	echo "Error: User '$USER' does not exist" >&2
+	exit 1
+fi
+
+if ! getent group "$GROUP" &>/dev/null; then
+	echo "Error: Group '$GROUP' does not exist" >&2
+	exit 1
+fi
+
+# Remove user from the group
+if groups "$USER" | grep -q "\b$GROUP\b"; then
+	if gpasswd -d "$USER" "$GROUP"; then
+		echo "User '$USER' removed from group '$GROUP'."
+	else
+		echo "Error: Failed to remove user '$USER' from group '$GROUP'" >&2
+		exit 1
+	fi
+fi
+
+exit 0

--- a/telegraf/delphix-telegraf-service
+++ b/telegraf/delphix-telegraf-service
@@ -1,10 +1,16 @@
 #!/bin/bash
 BASE_CONFIG=/etc/telegraf/telegraf.base
 DOSE_INPUTS=/etc/telegraf/telegraf.inputs.dose
+DCT_INPUTS=/etc/telegraf/telegraf.inputs.dct
 PLAYBOOK_INPUTS=/etc/telegraf/telegraf.inputs.playbook
 PLAYBOOK_FLAG=/etc/telegraf/PLAYBOOK_ENABLED
 TELEGRAF_CONFIG=/etc/telegraf/telegraf.conf
 
+
+function engine_is_dct() {
+	/usr/bin/get-appliance-variant | grep -q "dct" >/dev/null
+	[[ "$?" == "0" ]]
+}
 
 function engine_is_object_based() {
 	zdb -C | grep "type: 'object_store'" >/dev/null
@@ -22,6 +28,12 @@ if engine_is_object_based; then
 		cat $PLAYBOOK_INPUTS $DOSE_INPUTS $BASE_CONFIG > $TELEGRAF_CONFIG
 	else
 		cat $DOSE_INPUTS $BASE_CONFIG > $TELEGRAF_CONFIG
+	fi
+elif engine_is_dct; then
+	if playbook_is_enabled; then
+		cat $PLAYBOOK_INPUTS $DCT_INPUTS $BASE_CONFIG > $TELEGRAF_CONFIG
+	else
+		cat $DCT_INPUTS $BASE_CONFIG > $TELEGRAF_CONFIG
 	fi
 else
 	if playbook_is_enabled; then

--- a/telegraf/telegraf.base
+++ b/telegraf/telegraf.base
@@ -18,7 +18,7 @@
   rotation_max_size = "50MB"
   rotation_max_archives = 9
   data_format = "json"
-  namedrop = ["*estat_*", "agg_*", "zfs", "zpool*", "zcache*"]
+  namedrop = ["*estat_*", "agg_*", "zfs", "zpool*", "zcache*", "docker*"]
 
 # Define output file for ZFS related metrics
 [[outputs.file]]

--- a/telegraf/telegraf.inputs.dct
+++ b/telegraf/telegraf.inputs.dct
@@ -1,0 +1,22 @@
+#######################  Docker/DCT services Metrics  ################################
+[[inputs.docker]]
+  endpoint = "unix:///var/run/docker.sock"
+  interval = "60s"
+  timeout = "10s"
+  namepass = [
+    "docker_container_cpu",
+    "docker_container_mem",
+    "docker_container_blkio",
+    "docker_container_status"
+  ]
+  docker_label_exclude = ["com.docker.compose.*", "resty*"]
+
+ [[outputs.file]]
+  files = ["/var/log/telegraf/metrics_docker.json"]
+  rotation_max_size = "30MB"
+  rotation_max_archives = 5
+  data_format = "json"
+  namepass = ["docker*"]
+
+####################### End of Docker/DCT services Metrics #######################
+


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

All closed appliance DCT services are running inside Docker containers. 
Currently we do not collect any per-container metrics, but would like to do so to improve DCT engines diagnosability .

</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

We already use `delphix-telegraf` service to collect a lot of system-wide metrics.
It relies on telegraf to collect and store  the metrics.
To our benefit it has the build-in plugin for docker stats collection- [docker plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/docker)
We can extend the configuration file with docker metrics in case it runs on DCT engine.

To allow `telegraf` to collect  `docker` stats we need to add `telegraf` to `docker` user group.
That could be done during the `performance-diagnostics` package installation  or during the service startup time.

- Package installation:

  Implementation:
    - add a package dependency from `docker` package to `performance-diagnostic` package(`performance-diagnostics/debian/control`)
    - add `postinst` file to `performance-diagnostic` package, and use it to add `telegraf` user to `docker` user group
    - add `postrm` to revert that change

  Pros:
  + predictability (we will fail fast if there is an issue, during an upgrade or image build)

  Cons:
  - awkward package dependency `performance-diagnostic` <- `docker`
  - we adding the user to the group regardless of the engine type(DCT or not) - Not sure if there is an easy/correct way to separate these cases at the package installation level

- Service startup time:

  Implementation:
    - Modify [delphix-telegraf startup shell script](https://github.com/delphix/performance-diagnostics/blob/develop/telegraf/delphix-telegraf-service) to add `telegraf` user to `docker` user group

  Pros:
  + simplicity - We have all the packages installed at the service start time, so we know that `docker` package is installed and the `docker` user group exists. Do not need to introduce new dependencies.
  + flexibility - We have an easy way to differentiate DCT and virtualization/masking engines at that time

  Cons:
  - implicit service dependency on `docker` package


</details>


<details>
<summary><h2> Testing Done </h2></summary>

**How much data will we have in a support bundle**
The docker metrics file rotation policy set up to store 5 file 30MB each. That gives us 150MB of data max.
According to my experiments It takes ~60KB worth of data to store a single round of all the docker metrics.
`150MB / 120KB = ~40 hours worth of data.

```
delphix@ip-10-110-228-201:~$ sudo ls -la /var/log/telegraf/
total 3713
drwxr-xr-x  2 telegraf telegraf       7 Dec 13 03:47 .
drwxrwxr-x 15 root     syslog        31 Dec 13 04:09 ..
-rw-r--r--  1 telegraf telegraf  266311 Dec 13 04:08 metric_aggregates.json
-rw-r--r--  1 telegraf telegraf 8569688 Dec 13 04:16 metrics.json
-rw-r--r--  1 root     root      809837 Dec 13 04:16 metrics_docker.json
-rw-r--r--  1 telegraf telegraf       0 Dec 13 02:43 metrics_estat.json
-rw-r--r--  1 telegraf telegraf  722875 Dec 13 04:16 metrics_zfs.json
```

Upgade(virtualization engine and DCT closed appliance) has been manually tested using the artifacts created by `ab-pre-push`.
`ab-release.dlpxdc.co`
`ab-dct-release.dlpxdc.co`

[`ab-pre-push`](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10059/console)

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->


<details>
<summary><h2> Future Work </h2></summary>

@calder-delphix has kindly volunteered to help with adding the support for the new metrics to getmetrics-go[
](https://github.com/delphix/support-perfdb/tree/main/getmetrics-go) script that exports metrics from a support bundle to PerfDB -> Grafana dashboards.

</details>



<details>
<summary><h2> Bonus </h2></summary>

Updating python version to allow `flake8` check to run.
Fixing `flake8` issue in `cmd/nfs_threads.py`

</details>
