### PR TITLE
DLPX-93331 stbtrace invocations crash on 24.04

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -9,8 +9,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v1
-      with:
-        python-version: 3.6
     - name: flake8
       run: |
         python -m pip install --upgrade pip

--- a/bpf/estat/backend-io.c
+++ b/bpf/estat/backend-io.c
@@ -7,6 +7,7 @@
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <linux/blkdev.h>
+#include <linux/blk-mq.h>
 #include <linux/blk_types.h>
 #include <uapi/linux/bpf.h>
 

--- a/bpf/estat/backend-io.c
+++ b/bpf/estat/backend-io.c
@@ -35,7 +35,7 @@ int
 disk_io_start(struct pt_regs *ctx, struct request *reqp)
 {
 	io_data_t data = {};
-	struct gendisk *diskp = reqp->rq_disk;
+	struct gendisk *diskp = reqp->q->disk;
 	data.ts = bpf_ktime_get_ns();
 	data.cmd_flags = reqp->cmd_flags;
 	data.size = reqp->__data_len;

--- a/bpf/estat/iscsi.c
+++ b/bpf/estat/iscsi.c
@@ -48,7 +48,7 @@ BPF_HASH(iscsi_base_data, u32, iscsi_data_t);
 // @@ kprobe|iscsit_process_scsi_cmd|iscsi_target_start
 int
 iscsi_target_start(struct pt_regs *ctx, struct iscsi_conn *conn,
-    struct iscsi_cmd *cmd, struct iscsi_scsi_req *hdr)
+    struct iscsit_cmd *cmd, struct iscsi_scsi_req *hdr)
 {
 	u64 ts = bpf_ktime_get_ns();
 	iscsi_start_ts.update((u64 *) &cmd, &ts);
@@ -75,7 +75,7 @@ aggregate_data(iscsi_data_t *data, u64 ts, char *opstr)
 
 // @@ kprobe|iscsit_response_queue|iscsi_target_response
 int
-iscsi_target_response(struct pt_regs *ctx, struct iscsi_conn *conn, struct iscsi_cmd *cmd, int state)
+iscsi_target_response(struct pt_regs *ctx, struct iscsi_conn *conn, struct iscsit_cmd *cmd, int state)
 {
 	u32 tid = bpf_get_current_pid_tgid();
 	iscsi_data_t data = {};

--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -129,7 +129,7 @@ b = BPF(text=bpf_text)
 if BPF.get_kprobe_functions(b'blk_start_request'):
     b.attach_kprobe(event="blk_start_request", fn_name="disk_io_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="disk_io_start")
-b.attach_kprobe(event="blk_account_io_done", fn_name="disk_io_done")
+b.attach_kprobe(event="blk_mq_end_request", fn_name="disk_io_done")
 
 
 helper = BCCHelper(b, BCCHelper.ANALYTICS_PRINT_MODE)

--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -66,7 +66,7 @@ BPF_HASH($hist.name$, io_hist_key_t, u64);
 int disk_io_start(struct pt_regs *ctx, struct request *reqp)
 {
     io_data_t data = {};
-    struct gendisk *diskp = reqp->rq_disk;
+    struct gendisk *diskp = reqp->q->disk;
     data.ts = bpf_ktime_get_ns();
     data.cmd_flags = reqp->cmd_flags;
     data.size = reqp->__data_len;

--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -27,6 +27,7 @@ bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <linux/blkdev.h>
+#include <linux/blk-mq.h>
 #include <linux/blk_types.h>
 #include <uapi/linux/bpf.h>
 

--- a/bpf/stbtrace/iscsi.st
+++ b/bpf/stbtrace/iscsi.st
@@ -63,7 +63,7 @@ BPF_HASH($hist.name$, iscsi_hist_key_t, u64);
 
 // Probe functions to initialize thread local data
 int iscsi_target_start(struct pt_regs *ctx, struct iscsi_conn *conn,
-                       struct iscsi_cmd *cmd, struct iscsi_scsi_req *hdr)
+                       struct iscsit_cmd *cmd, struct iscsi_scsi_req *hdr)
 {
         u64 ts = bpf_ktime_get_ns();
         iscsi_start_ts.update((u64 *) &cmd, &ts);
@@ -72,7 +72,7 @@ int iscsi_target_start(struct pt_regs *ctx, struct iscsi_conn *conn,
 }
 
 int iscsi_target_response(struct pt_regs *ctx, struct iscsi_conn *conn,
-                          struct iscsi_cmd *cmd, int state)
+                          struct iscsit_cmd *cmd, int state)
 {
         u32 tid = bpf_get_current_pid_tgid();
         iscsi_data_t data = {};

--- a/cmd/nfs_threads.py
+++ b/cmd/nfs_threads.py
@@ -153,7 +153,7 @@ def print_line(interval):
     if e1 or e2 or e3:
         return
 
-    while(not sleep(interval)):
+    while not sleep(interval):
         nextCpuTime, e1 = cpu_time(pids)
         nextPackets, nextEnqueued, nextWoken, e2 = pool_stats()
         nextRB, nextWB, nextRO, nextWO, nextMeta, e3 = nfs_stats()


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

stbtrace invocations fail with:
1. 
```
delphix@pg-ntp:~$ sudo python3 /usr/bin/stbtrace io -a op -s avgLatency,latency,count,throughput
/virtual/main.c:45:33: error: incomplete definition of type 'struct request'
   45 |     struct gendisk *diskp = reqp->rq_disk;
      |                             ~~~~^
include/linux/blkdev.h:32:8: note: forward declaration of 'struct request'
   32 | struct request;
...
...
```
In this [kernel commit](https://github.com/torvalds/linux/commit/24b83deb29b7f06a5573b65f2ce96f5482755d43), the struct was moved from `linux/blkdev.h` to `linux/blk-mq.h`. 


2. After fixing this, I hit this error:
```
/virtual/main.c:46:35: error: no member named 'rq_disk' in 'struct request'
```

In this [kernel commit](https://github.com/torvalds/linux/commit/f3fa33acca9f0058157214800f68b10d8e71ab7a), the `rq_disk` field of the struct was removed and replaced with `q->disk`.


3. After fixing this, I hit this error:
```
[2025-02-11T09:02:46,006][ERROR][common.TracingScriptExecutor#readLine:50][Thread-11][] There were 1 errors in the last 10 minutes for script [io]. The first <= 50 unique error lines seen were:
cannot attach kprobe, Invalid argument
[2025-02-11T09:02:46,160][WARN][analytics.impl.datacollector.TracingDataCollector#reachedEof:205][Thread-10][] Tracing process for script [io] died without collecting any data. This likely means that the script failed to compile.


delphix@dlpx-palashgandhi-os-upgrade-qar-161994-766f97e2:~$ sudo /usr/bin/stbtrace io -a op -s avgLatency,latency,count,throughput
cannot attach kprobe, Invalid argument
Failed to attach BPF program b'disk_io_done' to kprobe b'blk_account_io_done', it's not traceable (either non-existing, inlined, or marked as "notrace")
```
According to https://github.com/iovisor/bcc/issues/5124 and the associated fix, this should be replaced with `blk_mq_end_request`
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

1. Include `linux/blk-mq.h` in our scripts.
2. Replace the use of `rq_disk` with `q->disk`
3. Replace `blk_account_io_done` with `blk_mq_end_request` 
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

`pre_checkin`: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/162274/console
```
11:49:56  test_create_domain - SUCCESS (0:04:37.032303)
```


`storage` which will run the `analytics_positive` suite: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/162276/console


`os_tests` which run the `performance_diagnostics_positive` suite to test estat: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/blackbox-self-service/162278/console
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
