### PR TITLE
DLPX-93447 test_estat_subcommands failed to run estat zvol command with compilation error

### DIFF
--- a/bpf/estat/zvol.c
+++ b/bpf/estat/zvol.c
@@ -12,6 +12,7 @@
 #include <sys/zfs_rlock.h>
 #include <sys/spa_impl.h>
 #include <sys/dataset_kstats.h>
+#include <sys/zvol.h>
 #include <sys/zvol_impl.h>
 
 


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

The `estat zvol` command fails on 24.04 with: 
```
10:54:26  dlpx-os-upgrade-qar-163491-766f97e2.dcol2.delphix.com: Error executing command "sudo -- timeout --preserve-status --signal=SIGINT 30 estat zvol 15". Code: 1. Error: In file included from /virtual/main.c:64:
10:54:26  /usr/src/zfs-6.8.0-47-dx2025012303-436f4ae50-generic/include/sys/zvol_impl.h:91:22: error: unknown type name 'zvol_state_handle_t'; did you mean 'depot_stack_handle_t'?
10:54:26     91 | int zvol_clone_range(zvol_state_handle_t *, uint64_t,
10:54:26        |                      ^~~~~~~~~~~~~~~~~~~
10:54:26        |                      depot_stack_handle_t
10:54:26  include/linux/stackdepot.h:25:13: note: 'depot_stack_handle_t' declared here
10:54:26     25 | typedef u32 depot_stack_handle_t;
10:54:26        |             ^
10:54:26  In file included from /virtual/main.c:64:
10:54:26  /usr/src/zfs-6.8.0-47-dx2025012303-436f4ae50-generic/include/sys/zvol_impl.h:92:5: error: unknown type name 'zvol_state_handle_t'; did you mean 'depot_stack_handle_t'?
10:54:26     92 |     zvol_state_handle_t *, uint64_t, uint64_t);
10:54:26        |     ^~~~~~~~~~~~~~~~~~~
10:54:26        |     depot_stack_handle_t
10:54:26  include/linux/stackdepot.h:25:13: note: 'depot_stack_handle_t' declared here
10:54:26     25 | typedef u32 depot_stack_handle_t;
10:54:26        |             ^
10:54:26  2 errors generated.
10:54:26  Traceback (most recent call last):
10:54:26    File "/usr/bin/estat", line 413, in <module>
10:54:26      b = BPF(text=bpf_text, cflags=cflags, debug=debug_level)
10:54:26          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
10:54:26    File "/usr/lib/python3/dist-packages/bcc/__init__.py", line 479, in __init__
10:54:26      raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
```
The problem is a missing include directive in `zvol_impl.h`. https://github.com/openzfs/zfs/commit/9dd5fe1095df246299df9a953a9c4994142636c2
caused this.
`zvol_state_handle_t` is declared in `sys/zvol.h` which is not included in `zvol_impl.h`.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

There were 2 fixes: include `zvol.h` in `zvol_impl.h` or do what upstream does, include `zvol.h` whenever including `zvol_impl.h`. This is likely why upstream doesn't see this issue. As such, I chose the latter here but have tested both fixes.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10452/

```
delphix@ip-10-110-202-51:~$ sudo estat zvol 15
02/24/25 - 16:33:27 UTC

 Tracing enabled... Hit Ctrl-C to end.
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
