### PR TITLE
APIGW-11280 Final image validation failed due to delphix-telegraf.service state inactive on 2025.1.0.0 image

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -24,4 +24,6 @@ if ! groups "$USER" | grep -q "\b$GROUP\b"; then
 	fi
 fi
 
+#DEBHELPER#
+
 exit 0


### PR DESCRIPTION
<h2> Problem </h2>

The `delphix-telegraf.service` is not automatically starting in Engine version 2025.1.0.0 .

<h2> Solution </h2>

The issue was introduced in #97 where a new postinst script was added for the service but was not setup to automatically enable the service. Per the `man` page for `debhelper`:

> Automatic generation of Debian install scripts Some debhelper commands will automatically generate parts of Debian maintainer scripts. If you want these automatically generated things included in your existing Debian maintainer scripts, then you need to add #DEBHELPER# to your scripts, in the place the code should be added.  #DEBHELPER# will be replaced by any auto-generated code when you run dh_installdeb.

This indicates that we need to add the `#DBEHELPER#` placeholder in the postinst script. This is further enforced by similar online inquires about the issue (example: https://unix.stackexchange.com/a/423078) .

<h2> Testing Done </h2>

__AUTOMATED:__

- `git-ab-pre-push` (mostly pass): https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10484/console
-- Note: The BlackBox runs within the `dx-integration-tests` and `upgrade-testing` downstream jobs both failed. The problem is in common VDB provision helpers unrelated to this change.
-- The failures are due to recent break tracked by DLPXQA-48396 . 

__MANUAL:__

- Spun up the Engine VM built by the `ab-pre-push` run
- Verified the service was running as expected:
```
$ systemctl status delphix-telegraf.service
● delphix-telegraf.service - Delphix Telegraf Metric Collection Agent
     Loaded: loaded (/lib/systemd/system/delphix-telegraf.service; enabled; vendor preset: enabled)
     Active: active (running) since Mon 2024-06-17 20:30:20 UTC; 2 days ago
       Docs: https://github.com/influxdata/telegraf
   Main PID: 4964 (delphix-telegra)
      Tasks: 13 (limit: 8812)
     Memory: 145.4M
     CGroup: /system.slice/delphix-telegraf.service
             ├─4964 /bin/bash /usr/bin/delphix-telegraf-service
             └─5283 /usr/bin/telegraf -config /etc/telegraf/telegraf.conf
```

- Inspected the `postinst` script on the system and verified the logic to enable the service was inserted in the placeholder:
```
$ more /var/lib/dpkg/info/performance-diagnostics.postinst
#!/bin/bash

USER="telegraf"
GROUP="docker"

# Ensure user and group exist
if ! id "$USER" &>/dev/null; then
    echo "Error: User '$USER' does not exist" >&2
    exit 1
fi

if ! getent group "$GROUP" &>/dev/null; then
    echo "Error: Group '$GROUP' does not exist" >&2
    exit 1
fi

# Add user to the group if not already a member
if ! groups "$USER" | grep -q "\b$GROUP\b"; then
    if usermod -a -G "$GROUP" "$USER"; then
        echo "User '$USER' added to group '$GROUP'."
    else
        echo "Error: Failed to add user '$USER' to group '$GROUP'" >&2
        exit 1
    fi
fi

# Automatically added by dh_systemd_enable/12.10ubuntu1
if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
    # This will only remove masks created by d-s-h on package removal.
    deb-systemd-helper unmask 'delphix-telegraf.service' >/dev/null || true

    # was-enabled defaults to true, so new installations run enable.
    if deb-systemd-helper --quiet was-enabled 'delphix-telegraf.service'; then
        # Enables the unit on first installation, creates new
        # symlinks on upgrades if the unit file has changed.
        deb-systemd-helper enable 'delphix-telegraf.service' >/dev/null || true
    else
        # Update the statefile to add new symlinks (if any), which need to be
        # cleaned up on purge. Also remove old symlinks.
        deb-systemd-helper update-state 'delphix-telegraf.service' >/dev/null || true
    fi
fi
# End automatically added section
# Automatically added by dh_systemd_start/12.10ubuntu1
if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
    if [ -d /run/systemd/system ]; then
        systemctl --system daemon-reload >/dev/null || true
        if [ -n "$2" ]; then
            _dh_action=restart
        else
            _dh_action=start
        fi
        deb-systemd-invoke $_dh_action 'delphix-telegraf.service' >/dev/null || true
    fi
fi
# End automatically added section


exit 0
```