### PR TITLE
DLPX-93204 estat and stbtrace miss nfsv4 writes

### DIFF
--- a/bpf/estat/nfs-by-client.c
+++ b/bpf/estat/nfs-by-client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Delphix. All rights reserved.
+ * Copyright 2019, 2025 Delphix. All rights reserved.
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
@@ -154,7 +154,7 @@ nfsd4_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *cstate,
 	nfs_data_t data = {};
 	data.ts = bpf_ktime_get_ns();
 	data.size = 0;
-	data.write_arg = &(nfs_write->wr_bytes_written);
+	data.write_arg = &nfs_write->wr_buflen;
 	data.sync = ASYNC_WRITE; // Assume async write, sync writes detected
 	data.cached = AXIS_NOT_APPLICABLE;
 	bpf_probe_read_str(&data.client, CLIENT_LEN, rqstp->rq_client->name);

--- a/bpf/estat/nfs.c
+++ b/bpf/estat/nfs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Delphix. All rights reserved.
+ * Copyright 2019, 2025 Delphix. All rights reserved.
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
@@ -154,7 +154,7 @@ nfsd4_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *cstate,
 	nfs_data_t data = {};
 	data.ts = bpf_ktime_get_ns();
 	data.size = 0;
-	data.write_arg = &(nfs_write->wr_bytes_written);
+	data.write_arg = &nfs_write->wr_buflen;
 	data.sync = ASYNC_WRITE; // Assume async write, sync writes detected
 	data.cached = AXIS_NOT_APPLICABLE;
 	bpf_probe_read_str(&data.client, CLIENT_LEN, rqstp->rq_client->name);

--- a/bpf/stbtrace/nfs.st
+++ b/bpf/stbtrace/nfs.st
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 by Delphix. All rights reserved.
+# Copyright (c) 2019, 2025 by Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -172,7 +172,7 @@ int nfsd4_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp,
     nfs_data_t data = {};
     data.ts = bpf_ktime_get_ns();
     data.size = 0;
-    data.write_arg = nfs_write;
+    data.write_arg = &nfs_write->wr_buflen;
     data.sync = ASYNC_WRITE; // Assume async write, sync writes detected
     data.cached = AXIS_NOT_APPLICABLE;
     bpf_probe_read_str(&data.client, CLIENT_LEN, rqstp->rq_client->name);
@@ -292,9 +292,7 @@ int nfsd4_write_done(struct pt_regs *ctx)
         return 0;   // missed issue
     }
 
-    bpf_probe_read(&nfs_write, sizeof(nfs_write), data->write_arg);
-    data->size = nfs_write.wr_bytes_written;
-
+    bpf_probe_read(&data->size, sizeof(u32), data->write_arg);
     aggregate_data(data, ts, WRITE_STR, NFSV4_STR);
     nfs_base_data.delete(&pid);
 

--- a/lib/iterative_template.py
+++ b/lib/iterative_template.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 Delphix. All rights reserved.
+# Copyright 2019, 2025 Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -52,7 +52,7 @@ class IterativeTemplate:
     TOP_ITERATIVE_REGEX = r"\$(\w+)\:(\{\w+\|[^}]*})\$"
 
     #
-    # The org.stringtemplate.v4 used int he scripts requires dollars
+    # The org.stringtemplate.v4 used in the scripts requires dollars
     # signs around template variables, e.g. $var$.  The trailing
     # dollar sign is removed to work with python string templates
     # using DOUBLE_DOLLAR_REGEX.


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

Both estat and stbtrace consistently report zero throughput when
measuring nfsv4 writes. Both use write probes that try to measure the
`wr_written` element of the `nfs4d_write` struct. The problem is that
nfsd4\_write returns before updating this, so it's always zero.
</details>

<details open>
<summary><h2> Solution </h2></summary>

Use the value of `wr_buflen` instead. This is what the tracepoint in
the Linux kernel does.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

Manual testing

https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10644/
</details>
