### PR TITLE
DLPX-94098 LTS 24.04: update performance-diagnostics for Ubuntu 24.04 appliance

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -9,8 +9,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v1
-      with:
-        python-version: "3.10"
     - name: flake8
       run: |
         python -m pip install --upgrade pip

--- a/bpf/estat/backend-io.c
+++ b/bpf/estat/backend-io.c
@@ -7,6 +7,7 @@
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <linux/blkdev.h>
+#include <linux/blk-mq.h>
 #include <linux/blk_types.h>
 #include <uapi/linux/bpf.h>
 
@@ -34,7 +35,7 @@ int
 disk_io_start(struct pt_regs *ctx, struct request *reqp)
 {
 	io_data_t data = {};
-	struct gendisk *diskp = reqp->rq_disk;
+	struct gendisk *diskp = reqp->q->disk;
 	data.ts = bpf_ktime_get_ns();
 	data.cmd_flags = reqp->cmd_flags;
 	data.size = reqp->__data_len;

--- a/bpf/estat/iscsi.c
+++ b/bpf/estat/iscsi.c
@@ -25,7 +25,8 @@
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
-#include "target/iscsi/iscsi_target_core.h"
+#include <scsi/libiscsi.h>
+#include <target/iscsi/iscsi_target_core.h>
 
 
 // Definitions for this script
@@ -48,7 +49,7 @@ BPF_HASH(iscsi_base_data, u32, iscsi_data_t);
 // @@ kprobe|iscsit_process_scsi_cmd|iscsi_target_start
 int
 iscsi_target_start(struct pt_regs *ctx, struct iscsi_conn *conn,
-    struct iscsi_cmd *cmd, struct iscsi_scsi_req *hdr)
+    struct iscsit_cmd *cmd, struct iscsi_scsi_req *hdr)
 {
 	u64 ts = bpf_ktime_get_ns();
 	iscsi_start_ts.update((u64 *) &cmd, &ts);
@@ -75,7 +76,7 @@ aggregate_data(iscsi_data_t *data, u64 ts, char *opstr)
 
 // @@ kprobe|iscsit_response_queue|iscsi_target_response
 int
-iscsi_target_response(struct pt_regs *ctx, struct iscsi_conn *conn, struct iscsi_cmd *cmd, int state)
+iscsi_target_response(struct pt_regs *ctx, struct iscsi_conn *conn, struct iscsit_cmd *cmd, int state)
 {
 	u32 tid = bpf_get_current_pid_tgid();
 	iscsi_data_t data = {};

--- a/bpf/estat/zvol.c
+++ b/bpf/estat/zvol.c
@@ -12,6 +12,7 @@
 #include <sys/zfs_rlock.h>
 #include <sys/spa_impl.h>
 #include <sys/dataset_kstats.h>
+#include <sys/zvol.h>
 #include <sys/zvol_impl.h>
 
 

--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -27,6 +27,7 @@ bpf_text += """
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <linux/blkdev.h>
+#include <linux/blk-mq.h>
 #include <linux/blk_types.h>
 #include <uapi/linux/bpf.h>
 
@@ -65,7 +66,7 @@ BPF_HASH($hist.name$, io_hist_key_t, u64);
 int disk_io_start(struct pt_regs *ctx, struct request *reqp)
 {
     io_data_t data = {};
-    struct gendisk *diskp = reqp->rq_disk;
+    struct gendisk *diskp = reqp->q->disk;
     data.ts = bpf_ktime_get_ns();
     data.cmd_flags = reqp->cmd_flags;
     data.size = reqp->__data_len;
@@ -128,7 +129,7 @@ b = BPF(text=bpf_text)
 if BPF.get_kprobe_functions(b'blk_start_request'):
     b.attach_kprobe(event="blk_start_request", fn_name="disk_io_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="disk_io_start")
-b.attach_kprobe(event="blk_account_io_done", fn_name="disk_io_done")
+b.attach_kprobe(event="blk_mq_end_request", fn_name="disk_io_done")
 
 
 helper = BCCHelper(b, BCCHelper.ANALYTICS_PRINT_MODE)

--- a/bpf/stbtrace/iscsi.st
+++ b/bpf/stbtrace/iscsi.st
@@ -63,7 +63,7 @@ BPF_HASH($hist.name$, iscsi_hist_key_t, u64);
 
 // Probe functions to initialize thread local data
 int iscsi_target_start(struct pt_regs *ctx, struct iscsi_conn *conn,
-                       struct iscsi_cmd *cmd, struct iscsi_scsi_req *hdr)
+                       struct iscsit_cmd *cmd, struct iscsi_scsi_req *hdr)
 {
         u64 ts = bpf_ktime_get_ns();
         iscsi_start_ts.update((u64 *) &cmd, &ts);
@@ -72,7 +72,7 @@ int iscsi_target_start(struct pt_regs *ctx, struct iscsi_conn *conn,
 }
 
 int iscsi_target_response(struct pt_regs *ctx, struct iscsi_conn *conn,
-                          struct iscsi_cmd *cmd, int state)
+                          struct iscsit_cmd *cmd, int state)
 {
         u32 tid = bpf_get_current_pid_tgid();
         iscsi_data_t data = {};

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 Delphix. All rights reserved.
+# Copyright 2019, 2024 Delphix. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -13,6 +13,6 @@ Standards-Version: 4.1.2
 
 Package: performance-diagnostics
 Architecture: any
-Depends: python3-bcc, python3-minimal, python3-psutil, telegraf, docker.io
+Depends: python3-bpfcc, python3-minimal, python3-psutil, telegraf, docker.io
 Description: eBPF-based Performance Diagnostic Tools
   A collection of eBPF-based tools for diagnosing performance issues.


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
We need to port the changes made on the os-upgrade branch to develop, for the 2025.4.0.0 release.
</details>

<details open>
<summary><h2> Solution </h2></summary>

- Note, this will need to be integrated simultaneously with all the other LTS changes on other repositories, after code-complete.
- This PR has all the changes made on the os-upgrade branch, cherry-picked and squashed into a single commit for integration on the develop branch.
  - DLPX-93498 LTS 24.04: Warning generated due to missing header declaring struct iscsi_conn (#103)
  - DLPX-93447 test_estat_subcommands failed to run estat zvol command with compilation error (#102)
  - DLPX-93331 stbtrace invocations crash on 24.04 (#101)
  - DLPX-92877 performance-diagnostics dependencies need to be updated to allow installation on 24.04 (#96)
  
</details>
