### PR TITLE
DLPX-93371 test_stbtrace_io failed because it stbtrace did not produce any output

### DIFF
--- a/bpf/estat/backend-io.c
+++ b/bpf/estat/backend-io.c
@@ -30,10 +30,12 @@ typedef struct {
 
 BPF_HASH(io_base_data, u64, io_data_t);
 
-// @@ kprobe|blk_mq_start_request|disk_io_start
+// @@ raw_tracepoint|block_io_start|disk_io_start
 int
-disk_io_start(struct pt_regs *ctx, struct request *reqp)
+disk_io_start(struct bpf_raw_tracepoint_args *ctx)
 {
+	struct request *reqp = (struct request *)ctx->args[0];
+
 	io_data_t data = {};
 	struct gendisk *diskp = reqp->q->disk;
 	data.ts = bpf_ktime_get_ns();
@@ -44,10 +46,12 @@ disk_io_start(struct pt_regs *ctx, struct request *reqp)
 	return (0);
 }
 
-// @@ kprobe|blk_account_io_done|disk_io_done
+// @@ raw_tracepoint|block_io_done|disk_io_done
 int
-disk_io_done(struct pt_regs *ctx, struct request *reqp)
+disk_io_done(struct bpf_raw_tracepoint_args *ctx)
 {
+	struct request *reqp = (struct request *)ctx->args[0];
+
 	u64 ts = bpf_ktime_get_ns();
 	io_data_t *data = io_base_data.lookup((u64 *) &reqp);
 	struct bio *bp = reqp->bio;

--- a/bpf/stbtrace/io.st
+++ b/bpf/stbtrace/io.st
@@ -63,8 +63,10 @@ $hists:{hist|
 BPF_HASH($hist.name$, io_hist_key_t, u64);
 }$
 
-int disk_io_start(struct pt_regs *ctx, struct request *reqp)
+int disk_io_start(struct bpf_raw_tracepoint_args *ctx)
 {
+    struct request *reqp = (struct request *)ctx->args[0];
+
     io_data_t data = {};
     struct gendisk *diskp = reqp->q->disk;
     data.ts = bpf_ktime_get_ns();
@@ -101,8 +103,10 @@ static int aggregate_data(io_data_t *data, u64 ts, char *opstr)
     return 0;
 }
 
-int disk_io_done(struct pt_regs *ctx, struct request *reqp)
+int disk_io_done(struct bpf_raw_tracepoint_args *ctx)
 {
+    struct request *reqp = (struct request *)ctx->args[0];
+
     u64 ts = bpf_ktime_get_ns();
     io_data_t *data = io_base_data.lookup((u64 *) &reqp);
     struct bio *bp = reqp->bio;
@@ -126,10 +130,8 @@ int disk_io_done(struct pt_regs *ctx, struct request *reqp)
 """  # noqa: W293
 b = BPF(text=bpf_text)
 
-if BPF.get_kprobe_functions(b'blk_start_request'):
-    b.attach_kprobe(event="blk_start_request", fn_name="disk_io_start")
-b.attach_kprobe(event="blk_mq_start_request", fn_name="disk_io_start")
-b.attach_kprobe(event="blk_mq_end_request", fn_name="disk_io_done")
+b.attach_raw_tracepoint("block_io_start", fn_name="disk_io_start")
+b.attach_raw_tracepoint("block_io_done", fn_name="disk_io_done")
 
 
 helper = BCCHelper(b, BCCHelper.ANALYTICS_PRINT_MODE)

--- a/cmd/estat.py
+++ b/cmd/estat.py
@@ -440,6 +440,8 @@ for line in input_text.splitlines():
             else:
                 print("WARNING: {}: {} - not found"
                       .format(probe_type, probe_spec[1]))
+        elif probe_type == "raw_tracepoint":
+            b.attach_raw_tracepoint(probe_spec[1], fn_name=probe_spec[2])
         elif probe_type == "kretprobe":
             b.attach_kretprobe(event=probe_spec[1], fn_name=probe_spec[2],
                                maxactive=MAXACTIVE)


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>
There'a set of bpftrace files that are failing with blk_mq_end_request for
kprobe. This fix is changing the kprobe to use a higher level function using 
raw tracepoints.

</details>

<details open>
<summary><h2> Problem </h2></summary>
After upgrading to 24.04, the stbtrace io command fails to generate any output.
</details>

<details open>
<summary><h2> Solution </h2></summary>
Using raw tracepoints and changing the callback to be traced was changed from
blk_mq_start_request to block_io_start, and blk_mq_end_request to block_io_done.
The underlying kernel functions did not always call blk_mq_end_request, so the output
for the kprobe was not always hit with a corresponding kprobe on blk_mq_start_request.

This way we can get the raw tracepoint of block_io_start/block_io_done, which is always called.
</details>


<details>
<summary><h2> Testing Done </h2></summary>
Running fio, iostat, and estat related tools.
</details>

<details>
<summary><h2> Implementation </h2></summary>
Changed kprobes to raw tracepoints.
</details>

