### PR TITLE
DLPX-95197 NFS_OPS analytics collector not working

### DIFF
--- a/bpf/estat/nfs.c
+++ b/bpf/estat/nfs.c
@@ -4,10 +4,15 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+struct bpf_wq {
+	__u64 __opaque[2];
+} __attribute__((aligned(8)));
+
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
 #include <linux/sunrpc/svc.h>
+#include <linux/nfs4.h>
 
 
 // nfsd4 definitions from fs/nfsd/xdr4.h
@@ -30,32 +35,29 @@ typedef struct {
 	stateid_opaque_t	si_opaque;
 } stateid_t;
 
-typedef struct {
-	stateid_t	rd_stateid;	/* request */
-	u64		rd_offset;	/* request */
-	u32		rd_length;	/* request */
-	int		rd_vlen;
-	struct file	*rd_filp;
-	bool		rd_tmp_file;
+struct nfsd4_read {
+        stateid_t               rd_stateid;         /* request */
+        u64                     rd_offset;          /* request */
+        u32                     rd_length;          /* request */
+        int                     rd_vlen;
+        struct nfsd_file        *rd_nf;
 
-	void		*rd_rqstp;	/* response */
-	void		*rd_fhp;	/* response */
-} nfsd4_read;
+        struct svc_rqst         *rd_rqstp;          /* response */
+        struct svc_fh           *rd_fhp;            /* response */
+        u32                     rd_eof;             /* response */
+};
 
-#define	NFS4_VERIFIER_SIZE	8
-typedef struct { char data[NFS4_VERIFIER_SIZE]; } nfs4_verifier;
+struct nfsd4_write {
+        stateid_t       wr_stateid;         /* request */
+        u64             wr_offset;          /* request */
+        u32             wr_stable_how;      /* request */
+        u32             wr_buflen;          /* request */
+        struct xdr_buf  wr_payload;         /* request */
 
-typedef struct {
-	stateid_t	wr_stateid;		/* request */
-	u64		wr_offset;		/* request */
-	u32		wr_stable_how;		/* request */
-	u32		wr_buflen;		/* request */
-	struct kvec	wr_head;
-	struct page	**wr_pagelist;		/* request */
-	u32		wr_bytes_written;	/* response */
-	u32		wr_how_written;		/* response */
-	nfs4_verifier	wr_verifier;		/* response */
-} nfsd4_write;
+        u32             wr_bytes_written;   /* response */
+        u32             wr_how_written;     /* response */
+        nfs4_verifier   wr_verifier;        /* response */
+};
 
 // Definitions for this script
 #define	READ_STR "read"
@@ -131,7 +133,7 @@ nfsd3_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
 // @@ kprobe|nfsd4_read|nfsd4_read_start
 int
 nfsd4_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *cstate,
-    nfsd4_read *nfs_read)
+    struct nfsd4_read *nfs_read)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	nfs_data_t data = {};
@@ -148,7 +150,7 @@ nfsd4_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *cstate,
 // @@ kprobe|nfsd4_write|nfsd4_write_start
 int
 nfsd4_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *cstate,
-    nfsd4_write *nfs_write)
+    struct nfsd4_write *nfs_write)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	nfs_data_t data = {};

--- a/bpf/stbtrace/nfs.st
+++ b/bpf/stbtrace/nfs.st
@@ -23,10 +23,16 @@ from bcchelper import BCCHelper   # noqa: E402
 # BPF txg program
 bpf_text = '#include "' + base_dir + 'lib/bcc_helper.h' + '"\n'
 bpf_text += """
+
+struct bpf_wq {
+	__u64 __opaque[2];
+} __attribute__((aligned(8)));
+
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf_common.h>
 #include <uapi/linux/bpf.h>
 #include <linux/sunrpc/svc.h>
+#include <linux/nfs4.h>
 
 
 // nfsd4 definitions from fs/nfsd/xdr4.h
@@ -35,45 +41,43 @@ bpf_text += """
 #define bool int
 
 typedef struct {
-    u32             cl_boot;
-    u32             cl_id;
+	u32		cl_boot;
+	u32		cl_id;
 } clientid_t;
 
 typedef struct {
-    clientid_t      so_clid;
-    u32             so_id;
+	clientid_t	so_clid;
+	u32		so_id;
 } stateid_opaque_t;
 
 typedef struct {
-    u32                     si_generation;
-    stateid_opaque_t        si_opaque;
+	u32			si_generation;
+	stateid_opaque_t	si_opaque;
 } stateid_t;
 
-typedef struct {
-    stateid_t       rd_stateid;     /* request */
-    u64		    rd_offset;      /* request */
-    u32             rd_length;      /* request */
-    int             rd_vlen;
-    struct file     *rd_filp;
-    bool            rd_tmp_file;
-    void            *rd_rqstp;      /* response */
-    void            *rd_fhp;        /* response */
-} nfsd4_read;
+struct nfsd4_read {
+        stateid_t               rd_stateid;         /* request */
+        u64                     rd_offset;          /* request */
+        u32                     rd_length;          /* request */
+        int                     rd_vlen;
+        struct nfsd_file        *rd_nf;
 
-#define NFS4_VERIFIER_SIZE      8
-typedef struct { char data[NFS4_VERIFIER_SIZE]; } nfs4_verifier;
+        struct svc_rqst         *rd_rqstp;          /* response */
+        struct svc_fh           *rd_fhp;            /* response */
+        u32                     rd_eof;             /* response */
+};
 
-typedef struct {
-    stateid_t       wr_stateid;         /* request */
-    u64             wr_offset;          /* request */
-    u32             wr_stable_how;      /* request */
-    u32             wr_buflen;          /* request */
-    struct kvec     wr_head;
-    struct page **  wr_pagelist;        /* request */
-    u32             wr_bytes_written;   /* response */
-    u32             wr_how_written;     /* response */
-    nfs4_verifier   wr_verifier;        /* response */
-} nfsd4_write;
+struct nfsd4_write {
+        stateid_t       wr_stateid;         /* request */
+        u64             wr_offset;          /* request */
+        u32             wr_stable_how;      /* request */
+        u32             wr_buflen;          /* request */
+        struct xdr_buf  wr_payload;         /* request */
+
+        u32             wr_bytes_written;   /* response */
+        u32             wr_how_written;     /* response */
+        nfs4_verifier   wr_verifier;        /* response */
+};
 
 // Definitions for this script
 #define READ_STR "read"
@@ -151,7 +155,7 @@ int nfsd3_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
 }
 
 int nfsd4_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *cstate,
-    nfsd4_read *nfs_read)
+    struct nfsd4_read *nfs_read)
 {
     u32 pid = bpf_get_current_pid_tgid();
     nfs_data_t data = {};
@@ -166,7 +170,7 @@ int nfsd4_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *cstate,
 }
 
 int nfsd4_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp,
-    void *cstate, nfsd4_write *nfs_write)
+    void *cstate, struct nfsd4_write *nfs_write)
 {
     u32 pid = bpf_get_current_pid_tgid();
     nfs_data_t data = {};
@@ -286,7 +290,7 @@ int nfsd4_write_done(struct pt_regs *ctx)
     u64 ts = bpf_ktime_get_ns();
     u32 pid = bpf_get_current_pid_tgid();
     nfs_data_t *data = nfs_base_data.lookup(&pid);
-    nfsd4_write nfs_write;
+    struct nfsd4_write nfs_write;
 
     if (data == 0) {
         return 0;   // missed issue


### PR DESCRIPTION
See my latest comment in the Jira issue. While I was here, I made sure that the various copies of structure definitions for NFSv4 reads and writes accurately reflects the current kernel definitions.

### Testing

ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/12027/

estat:
```
root@ip-10-110-237-28:~# estat nfs 10
... (bcc warnings elided)
4 warnings generated.
08/27/25 - 17:23:15 UTC

 Tracing enabled... Hit Ctrl-C to end.
   microseconds                                          v4/write, async
value range                 count ------------- Distribution -------------
[300, 400)                      7 |@@@@
[400, 500)                     34 |@@@@@@@@@@@@@@@@@@@
[500, 600)                      2 |@
[600, 700)                      4 |@@
[700, 800)                      4 |@@
[800, 900)                      4 |@@
[900, 1000)                     2 |@
[1000, 2000)                    7 |@@@@
[2000, 3000)                    3 |@@
[3000, 4000)                    2 |@
[4000, 5000)                    1 |@

                                       iops(/s)  avg latency(us)       stddev(us)  throughput(k/s)
v4/write, async                               7              822           608038             7168


                                       iops(/s)  throughput(k/s)
total                                         7             7168
```

backend analytics:
```
hercules=> select * from analytics_datapoint where statistic_type='NFS_OPS';
 data_id | statistic_type |                                                                                           data                                                                                           |      timestamp      |    removal_time     | resolution |            slice
---------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------+---------------------+------------+-----------------------------
    2332 | NFS_OPS        | {"op":"write","avgLatency":3936765,"latency":{"4000000":1},"count":1,"throughput":1048576}                                                                                               | 2025-08-27 17:22:11 | 2025-08-27 23:22:11 |          1 | ANALYTICS_STATISTIC_SLICE-5
    2748 | NFS_OPS        | {"op":"write","avgLatency":1414027,"latency":{"500000":4,"800000":3,"3000000":2,"4000000":2,"1000000":2,"5000000":1,"2000000":4,"400000":1,"700000":1},"count":20,"throughput":20971520} | 2025-08-27 17:23:22 | 2025-08-27 23:23:22 |          1 | ANALYTICS_STATISTIC_SLICE-5
    2734 | NFS_OPS        | {"count":1,"op":"write","throughput":1048576,"avgLatency":3652440,"latency":{"4000000":1}}                                                                                               | 2025-08-27 17:22:00 | 2025-09-03 17:22:00 |         60 | ANALYTICS_STATISTIC_SLICE-5
    2720 | NFS_OPS        | {"count":1,"op":"write","throughput":1048576,"avgLatency":3936765,"latency":{"4000000":1}}                                                                                               | 2025-08-27 17:22:00 | 2025-09-03 17:22:00 |         60 | ANALYTICS_STATISTIC_SLICE-5
    2749 | NFS_OPS        | {"op":"write","avgLatency":581127,"latency":{"500000":12,"3000000":1,"900000":1,"2000000":1,"400000":4,"700000":1},"count":20,"throughput":20971520}                                     | 2025-08-27 17:23:23 | 2025-08-27 23:23:23 |          1 | ANALYTICS_STATISTIC_SLICE-5
    2733 | NFS_OPS        | {"op":"write","avgLatency":551273,"latency":{"500000":7,"2000000":1,"400000":1,"300000":1},"count":10,"throughput":10485760}                                                             | 2025-08-27 17:23:19 | 2025-08-27 23:23:19 |          1 | ANALYTICS_STATISTIC_SLICE-5
    2719 | NFS_OPS        | {"op":"write","avgLatency":3652440,"latency":{"4000000":1},"count":1,"throughput":1048576}                                                                                               | 2025-08-27 17:22:17 | 2025-08-27 23:22:17 |          1 | ANALYTICS_STATISTIC_SLICE-5
    2741 | NFS_OPS        | {"op":"write","avgLatency":618214,"latency":{"500000":5,"800000":1,"900000":1,"2000000":1,"600000":1,"700000":1},"count":10,"throughput":10485760}                                       | 2025-08-27 17:23:21 | 2025-08-27 23:23:21 |          1 | ANALYTICS_STATISTIC_SLICE-5
(8 rows)
```