### PR TITLE
DLPX-88427 Filter garbage stat names from estat metaslab-alloc output

### DIFF
--- a/telegraf/metaslab-alloc-stats.sh
+++ b/telegraf/metaslab-alloc-stats.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Wrapper around "estat metaslab-alloc -jm 10" that filters out metrics whose
+# "name" tag contains garbage characters (DLPX-88427). A kernel bug causes
+# estat to occasionally emit stat names containing raw memory bytes or C macro
+# strings. Only names consisting of printable ASCII letters, digits, spaces,
+# and common punctuation are passed through.
+#
+estat metaslab-alloc -jm 10 | grep -E '"name":"[A-Za-z0-9 ,_()/.-]+"'

--- a/telegraf/telegraf.inputs.playbook
+++ b/telegraf/telegraf.inputs.playbook
@@ -91,9 +91,10 @@
   ]
   json_string_fields = ["iops(/s)", "avg latency(us)", "stddev(us)", "throughput(k/s)", "microseconds"]
 
-# Collect output from "estat metaslab-alloc -jm 10"
+# Collect output from "estat metaslab-alloc -jm 10" via wrapper script.
+# The wrapper filters out metrics with garbage "name" tags (DLPX-88427).
 [[inputs.execd]]
-  command = ["estat", "metaslab-alloc", "-jm", "10"]
+  command = ["/etc/telegraf/metaslab-alloc-stats.sh"]
   name_override = "estat_metaslab-alloc"
   signal = "none"
   restart_delay = "30s"


### PR DESCRIPTION
## Summary

- Wraps `estat metaslab-alloc -jm 10` in `/etc/telegraf/metaslab-alloc-stats.sh` that filters JSON lines whose `name` tag contains non-printable or non-standard characters
- Updates `telegraf.inputs.playbook` to invoke the wrapper script instead of calling `estat` directly
- Fixes DLPX-88427: a kernel bug causes `estat` to occasionally emit stat names containing raw memory bytes or C macro strings, producing unreadable metrics in Telegraf/InfluxDB

## Test plan

- [ ] Verify Telegraf picks up `metaslab-alloc-stats.sh` and collects `estat_metaslab-alloc` metrics normally
- [ ] Confirm that any lines with garbage `name` tags are dropped and do not appear in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)