### PR TITLE
DLPX-97802 Fix nfs bpftrace scripts to pick up kernel changes for nfs_read.

### DIFF
--- a/bpf/estat/nfs-by-client.c
+++ b/bpf/estat/nfs-by-client.c
@@ -96,10 +96,12 @@ BPF_HASH(nfs_base_data, u32, nfs_data_t);
 #define	NAME_LENGTH (VER_NAME_LEN + OP_NAME_LEN + IO_SUBTYPE_LEN)
 
 // Probe functions to initialize thread local data
+// Kernel signature: __be32 nfsd_read(struct svc_rqst *rqstp, struct svc_fh *fhp,
+//     loff_t offset, unsigned long *count, u32 *eof)
 // @@ kprobe|nfsd_read|nfsd3_read_start
 int
 nfsd3_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
-    u64 offset, void *vec, int vlen, u32 *count)
+    loff_t offset, unsigned long *count, u32 *eof)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	nfs_data_t data = {};
@@ -112,10 +114,13 @@ nfsd3_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
 	return (0);
 }
 
+// Kernel signature: __be32 nfsd_write(struct svc_rqst *rqstp, struct svc_fh *fhp,
+//     loff_t offset, struct kvec *vec, int vlen, unsigned long *cnt, int stable,
+//     __be32 *verf)
 // @@ kprobe|nfsd_write|nfsd3_write_start
 int
 nfsd3_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
-    u64 offset, void *vec, int vlen, u32 *count)
+    loff_t offset, void *vec, int vlen, unsigned long *count)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	nfs_data_t data = {};
@@ -251,7 +256,10 @@ nfsd3_aggregate_data(u64 ts, u32 type)
 	if (data == 0) {
 		return (0);   // missed issue
 	}
-	bpf_probe_read(&data->size, sizeof (u32), data->write_arg);
+	// Kernel stores the byte count in an unsigned long (8 bytes on x86_64)
+	// for both nfsd_read (arg 4) and nfsd_write (arg 6). Read the full width
+	// into data->size (u64) rather than truncating to 32 bits.
+	bpf_probe_read(&data->size, sizeof (unsigned long), data->write_arg);
 
 	aggregate_data(data, ts, type, NFSV3_STR);
 	nfs_base_data.delete(&pid);

--- a/bpf/estat/nfs.c
+++ b/bpf/estat/nfs.c
@@ -94,10 +94,12 @@ BPF_HASH(nfs_base_data, u32, nfs_data_t);
 #define	NAME_LENGTH (VER_NAME_LEN + OP_NAME_LEN + AXIS_LENGTH)
 
 // Probe functions to initialize thread local data
+// Kernel signature: __be32 nfsd_read(struct svc_rqst *rqstp, struct svc_fh *fhp,
+//     loff_t offset, unsigned long *count, u32 *eof)
 // @@ kprobe|nfsd_read|nfsd3_read_start
 int
 nfsd3_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
-    u64 offset, void *vec, int vlen, u32 *count)
+    loff_t offset, unsigned long *count, u32 *eof)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	nfs_data_t data = {};
@@ -110,10 +112,13 @@ nfsd3_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
 	return (0);
 }
 
+// Kernel signature: __be32 nfsd_write(struct svc_rqst *rqstp, struct svc_fh *fhp,
+//     loff_t offset, struct kvec *vec, int vlen, unsigned long *cnt, int stable,
+//     __be32 *verf)
 // @@ kprobe|nfsd_write|nfsd3_write_start
 int
 nfsd3_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
-    u64 offset, void *vec, int vlen, u32 *count)
+    loff_t offset, void *vec, int vlen, unsigned long *count)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	nfs_data_t data = {};
@@ -237,7 +242,10 @@ nfsd3_aggregate_data(u64 ts, u32 type)
 	if (data == 0) {
 		return (0);   // missed issue
 	}
-	bpf_probe_read(&data->size, sizeof (u32), data->write_arg);
+	// Kernel stores the byte count in an unsigned long (8 bytes on x86_64)
+	// for both nfsd_read (arg 4) and nfsd_write (arg 6). Read the full width
+	// into data->size (u64) rather than truncating to 32 bits.
+	bpf_probe_read(&data->size, sizeof (unsigned long), data->write_arg);
 
 	aggregate_data(data, ts, type, NFSV3_STR);
 	nfs_base_data.delete(&pid);

--- a/bpf/stbtrace/nfs.st
+++ b/bpf/stbtrace/nfs.st
@@ -122,8 +122,8 @@ BPF_HASH($hist.name$, nfs_hist_key_t, u64);
 }$
 
 // Probe functions to initialize thread local data
-// Kernel signature: __be32 nfsd_read(struct svc_rqst *rqstp, struct svc_fh *fhp,
-//     loff_t offset, unsigned long *count, u32 *eof)
+// Kernel signature: __be32 nfsd_read(struct svc_rqst *rqstp,
+//     struct svc_fh *fhp, off_t offset, unsigned long *count, u32 *eof)
 int nfsd3_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
     loff_t offset, unsigned long *count, u32 *eof)
 {
@@ -138,9 +138,10 @@ int nfsd3_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
     return 0;
 }
 
-// Kernel signature: __be32 nfsd_write(struct svc_rqst *rqstp, struct svc_fh *fhp,
-//     loff_t offset, struct kvec *vec, int vlen, unsigned long *cnt, int stable,
-//     __be32 *verf)
+// Kernel signature: __be32 nfsd_write(
+//     struct svc_rqst *rqstp, struct svc_fh *fhp,
+//     loff_t offset, struct kvec *vec, int vlen, unsigned long *cnt,
+//     int stable, __be32 *verf)
 int nfsd3_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
     loff_t offset, void *vec, int vlen, unsigned long *count)
 {

--- a/bpf/stbtrace/nfs.st
+++ b/bpf/stbtrace/nfs.st
@@ -122,8 +122,10 @@ BPF_HASH($hist.name$, nfs_hist_key_t, u64);
 }$
 
 // Probe functions to initialize thread local data
+// Kernel signature: __be32 nfsd_read(struct svc_rqst *rqstp, struct svc_fh *fhp,
+//     loff_t offset, unsigned long *count, u32 *eof)
 int nfsd3_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
-    u64 offset, void *vec, int vlen, u32 *count)
+    loff_t offset, unsigned long *count, u32 *eof)
 {
     u32 pid = bpf_get_current_pid_tgid();
     nfs_data_t data = {};
@@ -136,8 +138,11 @@ int nfsd3_read_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
     return 0;
 }
 
+// Kernel signature: __be32 nfsd_write(struct svc_rqst *rqstp, struct svc_fh *fhp,
+//     loff_t offset, struct kvec *vec, int vlen, unsigned long *cnt, int stable,
+//     __be32 *verf)
 int nfsd3_write_start(struct pt_regs *ctx, struct svc_rqst *rqstp, void *fhp,
-    u64 offset, void *vec, int vlen, u32 *count)
+    loff_t offset, void *vec, int vlen, unsigned long *count)
 {
     u32 pid = bpf_get_current_pid_tgid();
     nfs_data_t data = {};
@@ -244,7 +249,10 @@ static int nfsd3_aggregate_data(u64 ts, char *opstr)
     if (data == 0) {
         return 0;   // missed issue
     }
-    bpf_probe_read(&data->size, sizeof(u32), data->write_arg);
+    // Kernel stores the byte count in an unsigned long (8 bytes on x86_64) for
+    // both nfsd_read (arg 4) and nfsd_write (arg 6). Read the full width into
+    // data->size (u64) rather than truncating to 32 bits.
+    bpf_probe_read(&data->size, sizeof(unsigned long), data->write_arg);
 
     aggregate_data(data, ts, opstr, NFSV3_STR);
     nfs_base_data.delete(&pid);


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>
No results or throughput for nfs read calls.
</details>

<details open>
<summary><h2> Problem </h2></summary>

BPF trace scripts show no output for nfs reads. The kernel interface has changed.

</details>

<details open>
<summary><h2> Solution </h2></summary>

Update the nfs read calls related in the bpftrace scripts, incl the C files.

</details>


<details open>
<summary><h2> Testing Done </h2></summary>
CHANGES: 

delphix@ip-10-110-220-204:~$ sudo python3 /tmp/probe-test/cmd/stbtrace.py nfs       -a op,ver -s throughput,count,avgLatency
{"t":"1784759494", "op":"read", "ver":"v3", "count":"183", "avgLatency":"1615764", "throughput":"191889408"}

{"t":"1784759495", "op":"read", "ver":"v3", "count":"41", "avgLatency":"7121031", "throughput":"42991616"}

{"t":"1784759495", "op":"read", "ver":"v3", "count":"89", "avgLatency":"6376937", "throughput":"93323264"}

{"t":"1784759496", "op":"read", "ver":"v3", "count":"59", "avgLatency":"4935181", "throughput":"61865984"}

{"t":"1784759496", "op":"read", "ver":"v3", "count":"399", "avgLatency":"989877", "throughput":"418381824"}

{"t":"1784759497", "op":"read", "ver":"v3", "count":"253", "avgLatency":"627012", "throughput":"265289728"}

BASELINE:

delphix@ip-10-110-220-204:~sudo python3 /tmp/probe-baseline/cmd/stbtrace.py nfs \ \
      -a op,ver -s throughput,count,avgLatency
{"t":"1784759937", "op":"read", "ver":"v3", "count":"566", "avgLatency":"573190", "throughput":"0"}

{"t":"1784759937", "op":"read", "ver":"v3", "count":"295", "avgLatency":"589884", "throughput":"0"}

{"t":"1784759938", "op":"read", "ver":"v3", "count":"163", "avgLatency":"580014", "throughput":"0"}



</details>

